### PR TITLE
Use ko for building containers

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -9,10 +9,6 @@ on:
     tags:
       - "v*.*.*"
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   container:
     name: Build and push container
@@ -22,34 +18,9 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - uses: actions/checkout@v4
-      - name: Login to GHCR
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+      - uses: actions/setup-go@v5
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          provenance: false
-          build-args: TEST_ARCH=x86_64
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+          go-version: '1.22.4'
+      - uses: ko-build/setup-ko@v0.7
+      - run: ko build --base-import-paths

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,3 @@
+defaultPlatforms:
+- linux/amd64
+- linux/arm64


### PR DESCRIPTION
This cuts down build times as we use native golang cross compilation instead of emulating ARM via QEMU. Seems to cut down times from around 15 to 2 minutes.

It also simplifies the workflow YAML by quite a bit.

Discussed with @jschlyter