### PR TITLE
Improve paho logging and debug logging in general

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	cfgFile   string
-	edmLogger *slog.Logger
+	cfgFile        string
+	edmLogger      *slog.Logger
+	edmLoggerLevel *slog.LevelVar
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -26,9 +27,10 @@ outputting minimised output data.`,
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute(logger *slog.Logger) {
+func Execute(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 	// Set global variables so it can be used from run.go
 	edmLogger = logger
+	edmLoggerLevel = loggerLevel
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -13,7 +13,7 @@ var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run edm in dnstap capture mode",
 	Run: func(_ *cobra.Command, _ []string) {
-		runner.Run(edmLogger)
+		runner.Run(edmLogger, edmLoggerLevel)
 	},
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -30,7 +30,6 @@ func init() {
 	// is called directly, e.g.:
 	// runCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 
-	runCmd.Flags().Bool("debug", false, "print debug logging during operation")
 	runCmd.Flags().Bool("disable-session-files", false, "do not write out session parquet files")
 	runCmd.Flags().Bool("disable-histogram-sender", false, "do not check for histogram files to upload to core")
 	runCmd.Flags().Bool("disable-mqtt", false, "disable MQTT message sending")
@@ -76,8 +75,9 @@ func init() {
 	runCmd.Flags().String("http-client-cert-file", "edm-http-client.pem", "ECSDSA client cert used for authenticating to aggregate-receiver")
 	runCmd.Flags().String("http-url", "https://127.0.0.1:8443", "Service we will POST aggregates to")
 
+	// Debug options
+	runCmd.Flags().Bool("debug", false, "print debug logging during operation")
 	runCmd.Flags().String("debug-dnstap-filename", "", "File for dumping unmodified (sensitive) JSON-formatted dnstap packets we are about to process, for debugging")
-
 	runCmd.Flags().Bool("debug-enable-blockprofiling", false, "Enable profiling of goroutine blocking events")
 	runCmd.Flags().Bool("debug-enable-mutexprofiling", false, "Enable profiling of mutex contention events")
 

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func main() {
 		hostname = defaultHostname
 	}
 
+	// loggerLevel controls the global logging level for the application
 	loggerLevel := new(slog.LevelVar) // Info by default
 
 	// Logger used for all output

--- a/main.go
+++ b/main.go
@@ -20,8 +20,10 @@ func main() {
 		hostname = defaultHostname
 	}
 
+	loggerLevel := new(slog.LevelVar) // Info by default
+
 	// Logger used for all output
-	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: loggerLevel}))
 	logger = logger.With("service", "edm")
 	logger = logger.With("hostname", hostname)
 	logger = logger.With("go_version", runtime.Version())
@@ -31,5 +33,5 @@ func main() {
 	// well
 	slog.SetDefault(logger)
 
-	cmd.Execute(logger)
+	cmd.Execute(logger, loggerLevel)
 }

--- a/pkg/runner/mqtt.go
+++ b/pkg/runner/mqtt.go
@@ -23,7 +23,7 @@ type pahoDebugLogger struct {
 }
 
 func (pdl pahoDebugLogger) Println(v ...interface{}) {
-	pdl.logger.Debug(fmt.Sprintln(v...))
+	pdl.logger.Debug(fmt.Sprint(v...))
 }
 
 func (pdl pahoDebugLogger) Printf(format string, v ...interface{}) {
@@ -35,7 +35,7 @@ type pahoErrorLogger struct {
 }
 
 func (pel pahoErrorLogger) Println(v ...interface{}) {
-	pel.logger.Error(fmt.Sprintln(v...))
+	pel.logger.Error(fmt.Sprint(v...))
 }
 
 func (pel pahoErrorLogger) Printf(format string, v ...interface{}) {

--- a/pkg/runner/mqtt.go
+++ b/pkg/runner/mqtt.go
@@ -16,8 +16,14 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jws"
 )
 
-// Small structs that implements paho/log.Logger so we can use slog with extra info in
-// autopaho config logging
+const (
+	pahoLogTypeDebug      = "debug"
+	pahoLogTypeErrors     = "errors"
+	pahoLogTypePahoDebug  = "paho_debug"
+	pahoLogTypePahoErrors = "paho_errors"
+)
+
+// pahoDebugLogger implements paho/log.Logger interface for debug-level logging
 type pahoDebugLogger struct {
 	logger *slog.Logger
 }
@@ -30,6 +36,7 @@ func (pdl pahoDebugLogger) Printf(format string, v ...interface{}) {
 	pdl.logger.Debug(fmt.Sprintf(format, v...))
 }
 
+// pahoErrorLogger implements paho/log.Logger interface for error-level logging
 type pahoErrorLogger struct {
 	logger *slog.Logger
 }
@@ -58,10 +65,10 @@ func (edm *dnstapMinimiser) newAutoPahoClientConfig(caCertPool *x509.CertPool, s
 		KeepAlive:      mqttKeepAlive,
 		OnConnectionUp: func(*autopaho.ConnectionManager, *paho.Connack) { edm.log.Info("mqtt connection up") },
 		OnConnectError: func(err error) { edm.log.Error("error whilst attempting connection", "error", err) },
-		Debug:          pahoDebugLogger{logger: edm.log.With("paho_log_type", "debug")},
-		Errors:         pahoErrorLogger{logger: edm.log.With("paho_log_type", "errors")},
-		PahoDebug:      pahoDebugLogger{logger: edm.log.With("paho_log_type", "paho_debug")},
-		PahoErrors:     pahoErrorLogger{logger: edm.log.With("paho_log_type", "paho_errors")},
+		Debug:          pahoDebugLogger{logger: edm.log.With("paho_log_type", pahoLogTypeDebug)},
+		Errors:         pahoErrorLogger{logger: edm.log.With("paho_log_type", pahoLogTypeErrors)},
+		PahoDebug:      pahoDebugLogger{logger: edm.log.With("paho_log_type", pahoLogTypePahoDebug)},
+		PahoErrors:     pahoErrorLogger{logger: edm.log.With("paho_log_type", pahoLogTypePahoErrors)},
 		ClientConfig: paho.ClientConfig{
 			ClientID:      clientID,
 			OnClientError: func(err error) { edm.log.Error("server requested disconnect", "error", err) },

--- a/pkg/runner/mqtt.go
+++ b/pkg/runner/mqtt.go
@@ -5,17 +5,42 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/url"
 
 	"github.com/eclipse/paho.golang/autopaho"
 	"github.com/eclipse/paho.golang/autopaho/queue/file"
 	"github.com/eclipse/paho.golang/paho"
-	paholog "github.com/eclipse/paho.golang/paho/log"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jws"
 )
+
+// Small structs that implements paho/log.Logger so we can use slog with extra info in
+// autopaho config logging
+type pahoDebugLogger struct {
+	logger *slog.Logger
+}
+
+func (pdl pahoDebugLogger) Println(v ...interface{}) {
+	pdl.logger.Debug(fmt.Sprintln(v...))
+}
+
+func (pdl pahoDebugLogger) Printf(format string, v ...interface{}) {
+	pdl.logger.Debug(fmt.Sprintf(format, v...))
+}
+
+type pahoErrorLogger struct {
+	logger *slog.Logger
+}
+
+func (pel pahoErrorLogger) Println(v ...interface{}) {
+	pel.logger.Error(fmt.Sprintln(v...))
+}
+
+func (pel pahoErrorLogger) Printf(format string, v ...interface{}) {
+	pel.logger.Error(fmt.Sprintf(format, v...))
+}
 
 func (edm *dnstapMinimiser) newAutoPahoClientConfig(caCertPool *x509.CertPool, server string, clientID string, clientCertStore *certStore, mqttKeepAlive uint16, localFileQueue *file.Queue) (autopaho.ClientConfig, error) {
 	u, err := url.Parse(server)
@@ -33,10 +58,10 @@ func (edm *dnstapMinimiser) newAutoPahoClientConfig(caCertPool *x509.CertPool, s
 		KeepAlive:      mqttKeepAlive,
 		OnConnectionUp: func(*autopaho.ConnectionManager, *paho.Connack) { edm.log.Info("mqtt connection up") },
 		OnConnectError: func(err error) { edm.log.Error("error whilst attempting connection", "error", err) },
-		Debug:          paholog.NOOPLogger{},
-		Errors:         log.Default(),
-		PahoDebug:      paholog.NOOPLogger{},
-		PahoErrors:     log.Default(),
+		Debug:          pahoDebugLogger{logger: edm.log.With("paho_log_type", "debug")},
+		Errors:         pahoErrorLogger{logger: edm.log.With("paho_log_type", "errors")},
+		PahoDebug:      pahoDebugLogger{logger: edm.log.With("paho_log_type", "paho_debug")},
+		PahoErrors:     pahoErrorLogger{logger: edm.log.With("paho_log_type", "paho_errors")},
 		ClientConfig: paho.ClientConfig{
 			ClientID:      clientID,
 			OnClientError: func(err error) { edm.log.Error("server requested disconnect", "error", err) },
@@ -53,11 +78,6 @@ func (edm *dnstapMinimiser) newAutoPahoClientConfig(caCertPool *x509.CertPool, s
 	if localFileQueue != nil {
 		edm.log.Info("using file based queue for MQTT messages")
 		cliCfg.Queue = localFileQueue
-	}
-
-	if edm.debug {
-		cliCfg.Debug = log.Default()
-		cliCfg.PahoDebug = log.Default()
 	}
 
 	return cliCfg, nil


### PR DESCRIPTION
Make it so we can tag messages from paho internal logging in the slog messages, so we can now what part of paho created the message.

This also resulted in using the slog Debug level properly. edm will now set the slog loglevel to debug if the --debug flag is passed. This also resulted in some cleanup of the more verbose debug messages left in the code so it is actuallu possible to run edm on a real system with --debug enabled without generating massive amount of log messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logging functionality allows users to specify the logging level during command execution.
	- Introduced structured logging for improved clarity in log messages within the MQTT client configuration.

- **Bug Fixes**
	- Removed unnecessary debug logging to reduce noise in log outputs.

- **Documentation**
	- Updated method signatures to reflect the new logging level parameter for better clarity on usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->