### PR TITLE
Run golangci-lint as part of build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,5 +16,9 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Display Go version
         run: go version
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.60
       - name: Build
         run: make build

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
 linters:
   enable:
     - revive
+    - gofumpt
+    - gosec


### PR DESCRIPTION
Given the additional .golangci.yml changes this should roughly represent the linting tools mentioned in the README not already called from the Makefile.