### PR TITLE
Manage configuration in a struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/dnstap/golang-dnstap v0.4.0
 	github.com/eclipse/paho.golang v0.22.0
 	github.com/fsnotify/fsnotify v1.8.0
+	github.com/go-playground/validator/v10 v10.23.0
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.8
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/lestrrat-go/jwx/v2 v2.1.3
@@ -39,7 +40,10 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/dunglas/httpsfv v1.0.2 // indirect
 	github.com/farsightsec/golang-framestream v0.3.0 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/getsentry/sentry-go v0.30.0 // indirect
+	github.com/go-playground/locales v0.14.1 // indirect
+	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/goccy/go-json v0.10.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
@@ -50,6 +54,7 @@ require (
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.2 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
 	github.com/lestrrat-go/httprc v1.0.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,8 @@ github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7z
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
+github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/getsentry/sentry-go v0.30.0 h1:lWUwDnY7sKHaVIoZ9wYqRHJ5iEmoc0pqcRqFkosKzBo=
 github.com/getsentry/sentry-go v0.30.0/go.mod h1:WU9B9/1/sHDqeV8T+3VwwbjeR5MSXs/6aqG3mqZrezA=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -277,10 +279,18 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-latex/latex v0.0.0-20210118124228-b3d85cf34e07/go.mod h1:CO1AlKB2CSIqUrmQPqA0gdRIlnLEY0gK5JGjh37zN5U=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
+github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
+github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
+github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
+github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
+github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
+github.com/go-playground/validator/v10 v10.23.0 h1:/PwmTwZhS0dPkav3cdK9kV1FsAmrL8sThn8IHr/sO+o=
+github.com/go-playground/validator/v10 v10.23.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -493,6 +503,8 @@ github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LE
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
+github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
+github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/lestrrat-go/blackmagic v1.0.2 h1:Cg2gVSc9h7sz9NOByczrbUvLopQmXrfFx//N+AkAr5k=
 github.com/lestrrat-go/blackmagic v1.0.2/go.mod h1:UrEqBzIR2U6CnzVyUtfM6oZNMt/7O7Vohk2J0OGSAtU=
 github.com/lestrrat-go/httpcc v1.0.1 h1:ydWCStUeJLkpYyjLDHihupbn2tYmZ7m22BGkcvZZrIE=

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -99,7 +99,7 @@ type config struct {
 	Debug                     bool   `mapstructure:"debug"`
 	DebugDnstapFilename       string `mapstructure:"debug-dnstap-filename"`
 	DebugEnableBlockProfiling bool   `mapstructure:"debug-enable-blockprofiling"`
-	DebugEnableMutexPofiling  bool   `mapstructure:"debug-enable-mutexprofiling"`
+	DebugEnableMutexProfiling bool   `mapstructure:"debug-enable-mutexprofiling"`
 }
 
 const dawgNotFound = -1
@@ -883,7 +883,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 		logger.Info("enabling blocking profiling")
 		runtime.SetBlockProfileRate(int(time.Millisecond))
 	}
-	if startConf.DebugEnableMutexPofiling {
+	if startConf.DebugEnableMutexProfiling {
 		logger.Info("enabling mutex profiling")
 		runtime.SetMutexProfileFraction(100)
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -35,6 +35,7 @@ import (
 	"github.com/eclipse/paho.golang/autopaho"
 	"github.com/eclipse/paho.golang/autopaho/queue/file"
 	"github.com/fsnotify/fsnotify"
+	"github.com/go-playground/validator/v10"
 	_ "github.com/grafana/pyroscope-go/godeltaprof/http/pprof" // revive linter: keep blank import close to where it is used for now.
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/lestrrat-go/jwx/v2/jwa"
@@ -54,6 +55,52 @@ import (
 	"golang.org/x/crypto/argon2"
 	"google.golang.org/protobuf/proto"
 )
+
+// use a single instance of Validate, it caches struct info
+var validate = validator.New(validator.WithRequiredStructEnabled())
+
+type config struct {
+	ConfigFile                string `mapstructure:"config-file"`
+	DisableSessionFiles       bool   `mapstructure:"disable-session-files"`
+	DisableHistogramSender    bool   `mapstructure:"disable-histogram-sender"`
+	DisableMQTT               bool   `mapstructure:"disable-mqtt"`
+	DisableMQTTFilequeue      bool   `mapstructure:"disable-mqtt-filequeue"`
+	InputUnix                 string `mapstructure:"input-unix"`
+	InputTCP                  string `mapstructure:"input-tcp"`
+	InputTLS                  string `mapstructure:"input-tls"`
+	InputTLSCertFile          string `mapstructure:"input-tls-cert-file"`
+	InputTLSKeyFile           string `mapstructure:"input-tls-key-file"`
+	InputTLSClientCAFile      string `mapstructure:"input-tls-client-ca-file"`
+	CryptopanKey              string `mapstructure:"cryptopan-key" validate:"required"`
+	CryptopanKeySalt          string `mapstructure:"cryptopan-key-salt" validate:"required"`
+	WellKnownDomainsFile      string `mapstructure:"well-known-domains-file" validate:"required"`
+	IgnoredClientIPsFile      string `mapstructure:"ignored-client-ips-file"`
+	IgnoredQuestionNamesFile  string `mapstructure:"ignored-question-names-file"`
+	DataDir                   string `mapstructure:"data-dir" validate:"required"`
+	MinimiserWorkers          int    `mapstructure:"minimiser-workers" validate:"required"`
+	MQTTSigningKeyFile        string `mapstructure:"mqtt-signing-key-file"`
+	MQTTSigningKeyID          string `mapstructure:"mqtt-signing-key-id"`
+	MQTTClientKeyFile         string `mapstructure:"mqtt-client-key-file"`
+	MQTTClientCertFile        string `mapstructure:"mqtt-client-cert-file"`
+	MQTTServer                string `mapstructure:"mqtt-server"`
+	MQTTTopic                 string `mapstructure:"mqtt-topic"`
+	MQTTClientID              string `mapstructure:"mqtt-client-id"`
+	MQTTCAFile                string `mapstructure:"mqtt-ca-file"`
+	MQTTKeepalive             uint16 `mapstructure:"mqtt-keepalive"`
+	QnameSeenEntries          int    `mapstructure:"qname-seen-entries"`
+	CryptopanAddressEntries   int    `mapstructure:"cryptopan-address-entries"`
+	NewQnameBuffer            int    `mapstructure:"newqname-buffer"`
+	HTTPCAFile                string `mapstructure:"http-ca-file"`
+	HTTPSigningKeyFile        string `mapstructure:"http-signing-key-file"`
+	HTTPSigningKeyID          string `mapstructure:"http-signing-key-id"`
+	HTTPClientKeyFile         string `mapstructure:"http-client-key-file"`
+	HTTPClientCertFile        string `mapstructure:"http-client-cert-file"`
+	HTTPURL                   string `mapstructure:"http-url"`
+	Debug                     bool   `mapstructure:"debug"`
+	DebugDnstapFilename       string `mapstructure:"debug-dnstap-filename"`
+	DebugEnableBlockProfiling bool   `mapstructure:"debug-enable-blockprofiling"`
+	DebugEnableMutexPofiling  bool   `mapstructure:"debug-enable-mutexprofiling"`
+}
 
 const dawgNotFound = -1
 
@@ -406,7 +453,15 @@ func configUpdater(viperNotifyCh chan fsnotify.Event, edm *dnstapMinimiser) {
 	t := time.AfterFunc(math.MaxInt64, func() {
 		edm.log.Info("configUpdater: reacting to config file update", "filename", e.Name)
 
-		err := edm.setCryptopan(viper.GetString("cryptopan-key"), viper.GetString("cryptopan-key-salt"), viper.GetInt("cryptopan-address-entries"))
+		err := edm.updateConfig()
+		if err != nil {
+			edm.log.Error("configUpdater: unable to update edm config", "error", err)
+			return
+		}
+
+		conf := edm.getConfig()
+
+		err = edm.setCryptopan(conf.CryptopanKey, conf.CryptopanKeySalt, conf.CryptopanAddressEntries)
 		if err != nil {
 			edm.log.Error("configUpdater: unable to update cryptopan instance", "error", err)
 		}
@@ -434,13 +489,15 @@ func setHllDefaults() error {
 }
 
 func (edm *dnstapMinimiser) setupHistogramSender(httpClientCertStore *certStore) {
-	httpURL, err := url.Parse(viper.GetString("http-url"))
+	conf := edm.getConfig()
+
+	httpURL, err := url.Parse(conf.HTTPURL)
 	if err != nil {
 		edm.log.Error("unable to parse 'http-url' setting", "error", err)
 		os.Exit(1)
 	}
 
-	httpSigningKey, err := ed25519PrivateKeyFromFile(viper.GetString("http-signing-key-file"))
+	httpSigningKey, err := ed25519PrivateKeyFromFile(conf.HTTPSigningKeyFile)
 	if err != nil {
 		edm.log.Error("unable to parse key material from 'http-signing-key-file'", "error", err)
 		os.Exit(1)
@@ -449,16 +506,16 @@ func (edm *dnstapMinimiser) setupHistogramSender(httpClientCertStore *certStore)
 	// Leaving these nil will use the OS default CA certs
 	var httpCACertPool *x509.CertPool
 
-	if viper.GetString("http-ca-file") != "" {
+	if conf.HTTPCAFile != "" {
 		// Setup CA cert for validating the aggregate-receiver connection
-		httpCACertPool, err = certPoolFromFile(viper.GetString("http-ca-file"))
+		httpCACertPool, err = certPoolFromFile(conf.HTTPCAFile)
 		if err != nil {
 			edm.log.Error("failed to create CA cert pool for '-http-ca-file'", "error", err)
 			os.Exit(1)
 		}
 	}
 
-	edm.aggregSender, err = edm.newAggregateSender(httpURL, viper.GetString("http-signing-key-id"), httpSigningKey, httpCACertPool, httpClientCertStore)
+	edm.aggregSender, err = edm.newAggregateSender(httpURL, conf.HTTPSigningKeyID, httpSigningKey, httpCACertPool, httpClientCertStore)
 	if err != nil {
 		edm.log.Error("unable to create aggregate sender", "error", err)
 		os.Exit(1)
@@ -466,7 +523,9 @@ func (edm *dnstapMinimiser) setupHistogramSender(httpClientCertStore *certStore)
 }
 
 func (edm *dnstapMinimiser) setupMQTT(mqttClientCertStore *certStore) {
-	mqttSigningKey, err := ed25519PrivateKeyFromFile(viper.GetString("mqtt-signing-key-file"))
+	conf := edm.getConfig()
+
+	mqttSigningKey, err := ed25519PrivateKeyFromFile(conf.MQTTSigningKeyFile)
 	if err != nil {
 		edm.log.Error("unable to parse key material from 'mqtt-signing-key-file'", "error", err)
 		os.Exit(1)
@@ -475,18 +534,9 @@ func (edm *dnstapMinimiser) setupMQTT(mqttClientCertStore *certStore) {
 	// Leaving these nil will use the OS default CA certs
 	var mqttCACertPool *x509.CertPool
 
-	if viper.GetString("mqtt-ca-file") != "" {
+	if conf.MQTTCAFile != "" {
 		// Setup CA cert for validating the MQTT connection
-		mqttCACertPool, err = certPoolFromFile(viper.GetString("mqtt-ca-file"))
-		if err != nil {
-			edm.log.Error("failed to create CA cert pool for '--mqtt-ca-file'", "error", err)
-			os.Exit(1)
-		}
-	}
-
-	if viper.GetString("mqtt-ca-file") != "" {
-		// Setup CA cert for validating the MQTT connection
-		mqttCACertPool, err = certPoolFromFile(viper.GetString("mqtt-ca-file"))
+		mqttCACertPool, err = certPoolFromFile(conf.MQTTCAFile)
 		if err != nil {
 			edm.log.Error("failed to create CA cert pool for '--mqtt-ca-file'", "error", err)
 			os.Exit(1)
@@ -494,8 +544,8 @@ func (edm *dnstapMinimiser) setupMQTT(mqttClientCertStore *certStore) {
 	}
 
 	var mqttFileQueue *file.Queue
-	if !viper.GetBool("disable-mqtt-filequeue") {
-		mqttQueueDir := filepath.Join(viper.GetString("data-dir"), "mqtt", "queue")
+	if !conf.DisableMQTTFilequeue {
+		mqttQueueDir := filepath.Join(conf.DataDir, "mqtt", "queue")
 
 		err = os.MkdirAll(mqttQueueDir, 0o750)
 		if err != nil {
@@ -503,14 +553,14 @@ func (edm *dnstapMinimiser) setupMQTT(mqttClientCertStore *certStore) {
 			os.Exit(1)
 		}
 
-		mqttFileQueue, err = file.New(filepath.Join(viper.GetString("data-dir"), "mqtt", "queue"), "queue", ".msg")
+		mqttFileQueue, err = file.New(filepath.Join(conf.DataDir, "mqtt", "queue"), "queue", ".msg")
 		if err != nil {
 			edm.log.Error("unable to init MQTT queue file based queue", "error", err)
 			os.Exit(1)
 		}
 	}
 
-	autopahoConfig, err := edm.newAutoPahoClientConfig(mqttCACertPool, viper.GetString("mqtt-server"), viper.GetString("mqtt-client-id"), mqttClientCertStore, viper.GetUint16("mqtt-keepalive"), mqttFileQueue)
+	autopahoConfig, err := edm.newAutoPahoClientConfig(mqttCACertPool, conf.MQTTServer, conf.MQTTClientID, mqttClientCertStore, conf.MQTTKeepalive, mqttFileQueue)
 	if err != nil {
 		edm.log.Error("unable to create autopaho config", "error", err)
 		os.Exit(1)
@@ -538,7 +588,7 @@ func (edm *dnstapMinimiser) setupMQTT(mqttClientCertStore *certStore) {
 		os.Exit(1)
 	}
 
-	err = mqttJWK.Set(jwk.KeyIDKey, viper.GetString("mqtt-signing-key-id"))
+	err = mqttJWK.Set(jwk.KeyIDKey, conf.MQTTSigningKeyID)
 	if err != nil {
 		edm.log.Error("unable to set MQTT JWK `kid`", "error", err)
 		os.Exit(1)
@@ -546,7 +596,7 @@ func (edm *dnstapMinimiser) setupMQTT(mqttClientCertStore *certStore) {
 
 	// Connect to the broker - this will return immediately after initiating the connection process
 	edm.autopahoWg.Add(1)
-	go edm.runAutoPaho(autopahoCm, viper.GetString("mqtt-topic"), mqttJWK, mqttFileQueue != nil)
+	go edm.runAutoPaho(autopahoCm, conf.MQTTTopic, mqttJWK, mqttFileQueue != nil)
 }
 
 func (edm *dnstapMinimiser) setIgnoredQuestionNames(ignoredQuestionsFileName string) error {
@@ -750,27 +800,73 @@ func (edm *dnstapMinimiser) registerFSWatcher(filename string, callback func(str
 	return nil
 }
 
+type edmConfiger interface {
+	getConfig() (config, error)
+}
+
+type testConfiger struct {
+	CryptopanKey            string
+	CryptopanKeySalt        string
+	CryptopanAddressEntries int
+	Debug                   bool
+	DisableHistogramSender  bool
+	DisableMQTT             bool
+}
+
+func (tc testConfiger) getConfig() (config, error) {
+	return config{
+		CryptopanKey:            tc.CryptopanKey,
+		CryptopanKeySalt:        tc.CryptopanKeySalt,
+		CryptopanAddressEntries: tc.CryptopanAddressEntries,
+		Debug:                   tc.Debug,
+		DisableHistogramSender:  tc.DisableHistogramSender,
+		DisableMQTT:             tc.DisableMQTT,
+	}, nil
+}
+
+type viperConfiger struct{}
+
+func (vc viperConfiger) getConfig() (config, error) {
+	conf := config{}
+	err := viper.UnmarshalExact(&conf)
+	if err != nil {
+		return config{}, fmt.Errorf("getViperConfig: unable to unmarshal config: %w", err)
+	}
+
+	err = validate.Struct(conf)
+	if err != nil {
+		return config{}, fmt.Errorf("getViperConfig: unable to validate config: %w", err)
+	}
+
+	return conf, nil
+}
+
+func (edm *dnstapMinimiser) updateConfig() error {
+	edm.confMutex.Lock()
+	defer edm.confMutex.Unlock()
+
+	conf, err := edm.configer.getConfig()
+	if err != nil {
+		return err
+	}
+
+	edm.conf = conf
+
+	return nil
+}
+
+func (edm *dnstapMinimiser) getConfig() config {
+	edm.confMutex.RLock()
+	conf := edm.conf
+	edm.confMutex.RUnlock()
+
+	return conf
+}
+
 func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
-	if viper.GetBool("debug-enable-blockprofiling") {
-		logger.Info("enabling blocking profiling")
-		runtime.SetBlockProfileRate(int(time.Millisecond))
-	}
-	if viper.GetBool("debug-enable-mutexprofiling") {
-		logger.Info("enabling mutex profiling")
-		runtime.SetMutexProfileFraction(100)
-	}
-
-	if viper.GetString("cryptopan-key") == "" {
-		logger.Error("cryptopan setup error", "error", "missing required setting 'cryptopan-key' in config", "configfile", viper.ConfigFileUsed())
-		os.Exit(1)
-	}
-
-	if viper.GetBool("debug") {
-		loggerLevel.Set(slog.LevelDebug)
-	}
-
 	// Create an instance of the minimiser
-	edm, err := newDnstapMinimiser(logger, viper.GetString("cryptopan-key"), viper.GetString("cryptopan-key-salt"), viper.GetInt("cryptopan-address-entries"), viper.GetBool("debug"), viper.GetBool("disable-histogram-sender"), viper.GetBool("disable-mqtt"))
+	vc := viperConfiger{}
+	edm, err := newDnstapMinimiser(logger, vc)
 	if err != nil {
 		logger.Error("unable to init edm", "error", err)
 		os.Exit(1)
@@ -778,27 +874,45 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 	defer edm.stop()
 	defer edm.fsWatcher.Close()
 
-	err = edm.setIgnoredClientIPs(viper.GetString("ignored-client-ips-file"))
+	// Create startConf for some initial setup. Other edm methods that need
+	// to read the config should call edm.getConfig() internally so they
+	// get the latest config.
+	startConf := edm.getConfig()
+
+	if startConf.DebugEnableBlockProfiling {
+		logger.Info("enabling blocking profiling")
+		runtime.SetBlockProfileRate(int(time.Millisecond))
+	}
+	if startConf.DebugEnableMutexPofiling {
+		logger.Info("enabling mutex profiling")
+		runtime.SetMutexProfileFraction(100)
+	}
+
+	if startConf.Debug {
+		loggerLevel.Set(slog.LevelDebug)
+	}
+
+	err = edm.setIgnoredClientIPs(startConf.IgnoredClientIPsFile)
 	if err != nil {
 		logger.Error("unable to configure ignored client IPs", "error", err)
 		os.Exit(1)
 	}
 
-	err = edm.registerFSWatcher(viper.GetString("ignored-client-ips-file"), edm.setIgnoredClientIPs)
+	err = edm.registerFSWatcher(startConf.IgnoredClientIPsFile, edm.setIgnoredClientIPs)
 	if err != nil {
-		logger.Error("unable to register fsWatcher callback", "filename", viper.GetString("ignored-client-ips-file"), "error", err)
+		logger.Error("unable to register fsWatcher callback", "filename", startConf.IgnoredClientIPsFile, "error", err)
 		os.Exit(1)
 	}
 
-	err = edm.setIgnoredQuestionNames(viper.GetString("ignored-question-names-file"))
+	err = edm.setIgnoredQuestionNames(startConf.IgnoredQuestionNamesFile)
 	if err != nil {
-		logger.Error("unable to configure ignored client IPs", "error", err)
+		logger.Error("unable to configure ignored question names", "error", err)
 		os.Exit(1)
 	}
 
-	err = edm.registerFSWatcher(viper.GetString("ignored-question-names-file"), edm.setIgnoredQuestionNames)
+	err = edm.registerFSWatcher(startConf.IgnoredQuestionNamesFile, edm.setIgnoredQuestionNames)
 	if err != nil {
-		logger.Error("unable to register fsWatcher callback", "filename", viper.GetString("ignored-question-names-file"), "error", err)
+		logger.Error("unable to register fsWatcher callback", "filename", startConf.IgnoredQuestionNamesFile, "error", err)
 		os.Exit(1)
 	}
 
@@ -810,7 +924,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 		viperNotifyCh <- e
 	})
 
-	pdbDir := filepath.Join(viper.GetString("data-dir"), "pebble")
+	pdbDir := filepath.Join(startConf.DataDir, "pebble")
 	pdb, err := pebble.Open(pdbDir, &pebble.Options{})
 	if err != nil {
 		logger.Error("unable to open pebble database", "dir", pdbDir, "error", err)
@@ -826,7 +940,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 	if !edm.histogramSenderDisabled {
 		// Setup client cert/key for mTLS authentication
 		httpClientCertStore := newCertStore()
-		err = httpClientCertStore.setCert(viper.GetString("http-client-cert-file"), viper.GetString("http-client-key-file"))
+		err = httpClientCertStore.setCert(startConf.HTTPClientCertFile, startConf.HTTPClientKeyFile)
 		if err != nil {
 			edm.log.Error("unable to load x509 HTTP client cert", "error", err)
 			os.Exit(1)
@@ -834,13 +948,14 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 
 		edm.setupHistogramSender(httpClientCertStore)
 
-		err = edm.registerFSWatcher(viper.GetString("http-client-cert-file"), func(filename string) error {
+		err = edm.registerFSWatcher(startConf.HTTPClientCertFile, func(filename string) error {
+			conf := edm.getConfig()
 			edm.log.Info("reloading HTTP cert store because file was modified", "filename", filename)
-			err := httpClientCertStore.setCert(viper.GetString("http-client-cert-file"), viper.GetString("http-client-key-file"))
+			err := httpClientCertStore.setCert(conf.HTTPClientCertFile, conf.HTTPClientKeyFile)
 			return err
 		})
 		if err != nil {
-			logger.Error("unable to register fsWatcher callback", "filename", viper.GetString("http-client-cert-file"), "error", err)
+			logger.Error("unable to register fsWatcher callback", "filename", startConf.HTTPClientCertFile, "error", err)
 			os.Exit(1)
 		}
 	}
@@ -848,7 +963,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 	if !edm.mqttDisabled {
 		// Setup client cert/key for mTLS authentication
 		mqttClientCertStore := newCertStore()
-		err = mqttClientCertStore.setCert(viper.GetString("mqtt-client-cert-file"), viper.GetString("mqtt-client-key-file"))
+		err = mqttClientCertStore.setCert(startConf.MQTTClientCertFile, startConf.MQTTClientKeyFile)
 		if err != nil {
 			edm.log.Error("unable to load x509 mqtt client cert", "error", err)
 			os.Exit(1)
@@ -856,13 +971,14 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 
 		edm.setupMQTT(mqttClientCertStore)
 
-		err = edm.registerFSWatcher(viper.GetString("mqtt-client-cert-file"), func(filename string) error {
+		err = edm.registerFSWatcher(startConf.MQTTClientCertFile, func(filename string) error {
+			conf := edm.getConfig()
 			edm.log.Info("reloading MQTT cert store because file was modified", "filename", filename)
-			err := mqttClientCertStore.setCert(viper.GetString("mqtt-client-cert-file"), viper.GetString("mqtt-client-key-file"))
+			err := mqttClientCertStore.setCert(conf.MQTTClientCertFile, conf.MQTTClientKeyFile)
 			return err
 		})
 		if err != nil {
-			logger.Error("unable to register fsWatcher callback", "filename", viper.GetString("mqtt-client-cert-file"), "error", err)
+			logger.Error("unable to register fsWatcher callback", "filename", startConf.MQTTClientCertFile, "error", err)
 			os.Exit(1)
 		}
 	}
@@ -871,24 +987,24 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 
 	// Setup the dnstap.Input, only one at a time is supported.
 	var dti *dnstap.FrameStreamSockInput
-	if viper.GetString("input-unix") != "" {
-		logger.Info("creating dnstap unix socket", "socket", viper.GetString("input-unix"))
-		dti, err = dnstap.NewFrameStreamSockInputFromPath(viper.GetString("input-unix"))
+	if startConf.InputUnix != "" {
+		logger.Info("creating dnstap unix socket", "socket", startConf.InputUnix)
+		dti, err = dnstap.NewFrameStreamSockInputFromPath(startConf.InputUnix)
 		if err != nil {
 			logger.Error("unable to create dnstap unix socket", "error", err)
 			os.Exit(1)
 		}
-	} else if viper.GetString("input-tcp") != "" {
-		logger.Info("creating plaintext dnstap TCP socket", "socket", viper.GetString("input-tcp"))
-		l, err := net.Listen("tcp", viper.GetString("input-tcp"))
+	} else if startConf.InputTCP != "" {
+		logger.Info("creating plaintext dnstap TCP socket", "socket", startConf.InputTCP)
+		l, err := net.Listen("tcp", startConf.InputTCP)
 		if err != nil {
 			logger.Error("unable to create plaintext dnstap TCP socket", "error", err)
 			os.Exit(1)
 		}
 		dti = dnstap.NewFrameStreamSockInput(l)
-	} else if viper.GetString("input-tls") != "" {
-		logger.Info("creating encrypted dnstap TLS socket", "socket", viper.GetString("input-tls"))
-		dnstapInputCert, err := tls.LoadX509KeyPair(viper.GetString("input-tls-cert-file"), viper.GetString("input-tls-key-file"))
+	} else if startConf.InputTLS != "" {
+		logger.Info("creating encrypted dnstap TLS socket", "socket", startConf.InputTLS)
+		dnstapInputCert, err := tls.LoadX509KeyPair(startConf.InputTLSCertFile, startConf.InputTLSKeyFile)
 		if err != nil {
 			logger.Error("unable to load x509 dnstap listener cert", "error", err)
 			os.Exit(1)
@@ -899,9 +1015,9 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 		}
 
 		// Enable client mTLS (client cert auth) if a CA file was passed:
-		if viper.GetString("input-tls-client-ca-file") != "" {
-			logger.Info("dnstap socket requiring valid client certs", "ca-file", viper.GetString("input-tls-client-ca-file"))
-			inputTLSClientCACertPool, err := certPoolFromFile(viper.GetString("input-tls-client-ca-file"))
+		if startConf.InputTLSClientCAFile != "" {
+			logger.Info("dnstap socket requiring valid client certs", "ca-file", startConf.InputTLSClientCAFile)
+			inputTLSClientCACertPool, err := certPoolFromFile(startConf.InputTLSClientCAFile)
 			if err != nil {
 				logger.Error("failed to create CA cert pool for '-input-tls-client-ca-file': %s", "error", err)
 				os.Exit(1)
@@ -911,7 +1027,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 			dnstapTLSConfig.ClientCAs = inputTLSClientCACertPool
 		}
 
-		l, err := tls.Listen("tcp", viper.GetString("input-tls"), dnstapTLSConfig)
+		l, err := tls.Listen("tcp", startConf.InputTLS, dnstapTLSConfig)
 		if err != nil {
 			logger.Error("unable to create TCP listener", "error", err)
 			os.Exit(1)
@@ -931,7 +1047,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 	// domain list yet we have seen since we started. To limit the
 	// possibility of unbounded memory usage we use a LRU cache instead of
 	// something simpler like a map.
-	seenQnameLRU, err := lru.New[string, struct{}](viper.GetInt("qname-seen-entries"))
+	seenQnameLRU, err := lru.New[string, struct{}](startConf.QnameSeenEntries)
 	if err != nil {
 		logger.Error("unable to create seen-qname LRU", "error", err)
 		os.Exit(1)
@@ -955,7 +1071,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 
 	// Write histogram file to an outbox dir where it will get picked up by
 	// the histogram sender. Upon being sent it will be moved to the sent dir.
-	dataDir := viper.GetString("data-dir")
+	dataDir := startConf.DataDir
 	outboxDir := filepath.Join(dataDir, "parquet", "histograms", "outbox")
 	sentDir := filepath.Join(dataDir, "parquet", "histograms", "sent")
 
@@ -981,7 +1097,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 	wg.Add(1)
 	go edm.diskCleaner(&wg, sentDir)
 
-	dawgFile := viper.GetString("well-known-domains-file")
+	dawgFile := startConf.WellKnownDomainsFile
 
 	dawgFinder, dawgModTime, err := loadDawgFile(dawgFile)
 	if err != nil {
@@ -995,7 +1111,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 		os.Exit(1)
 	}
 
-	debugDnstapFilename := viper.GetString("debug-dnstap-filename")
+	debugDnstapFilename := startConf.DebugDnstapFilename
 
 	// Keep in mind that this file is unbuffered. We could wrap it in a
 	// bufio.NewWriter() if we want more performance out of it, but since
@@ -1026,7 +1142,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 
 	var minimiserWg sync.WaitGroup
 
-	numMinimiserWorkers := viper.GetInt("minimiser-workers")
+	numMinimiserWorkers := startConf.MinimiserWorkers
 	if numMinimiserWorkers <= 0 {
 		numMinimiserWorkers = runtime.GOMAXPROCS(0)
 	}
@@ -1035,7 +1151,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 	for minimiserID := 0; minimiserID < numMinimiserWorkers; minimiserID++ {
 		edm.log.Info("Run: starting minimiser worker", "minimiser_id", minimiserID)
 		minimiserWg.Add(1)
-		go edm.runMinimiser(minimiserID, &minimiserWg, seenQnameLRU, pdb, viper.GetBool("disable-session-files"), debugDnstapFile, labelLimit, wkdTracker)
+		go edm.runMinimiser(minimiserID, &minimiserWg, seenQnameLRU, pdb, startConf.DisableSessionFiles, debugDnstapFile, labelLimit, wkdTracker)
 	}
 
 	// Start dnstap.Input
@@ -1068,6 +1184,9 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 }
 
 type dnstapMinimiser struct {
+	configer                  edmConfiger
+	conf                      config
+	confMutex                 sync.RWMutex
 	inputChannel              chan []byte          // the channel expected to be passed to dnstap ReadInto()
 	log                       *slog.Logger         // any information logging is sent here
 	cryptopan                 *cryptopan.Cryptopan // used for pseudonymising IP addresses
@@ -1119,10 +1238,19 @@ func createCryptopan(key string, salt string) (*cryptopan.Cryptopan, error) {
 	return cpn, nil
 }
 
-func newDnstapMinimiser(logger *slog.Logger, cryptopanKey string, cryptopanSalt string, cryptopanCacheEntries int, debug bool, histogramSenderDisabled bool, mqttDisabled bool) (*dnstapMinimiser, error) {
-	edm := &dnstapMinimiser{}
+func newDnstapMinimiser(logger *slog.Logger, edmConf edmConfiger) (*dnstapMinimiser, error) {
+	edm := &dnstapMinimiser{
+		configer: edmConf,
+	}
 
-	err := edm.setCryptopan(cryptopanKey, cryptopanSalt, cryptopanCacheEntries)
+	err := edm.updateConfig()
+	if err != nil {
+		return nil, fmt.Errorf("newDnstapMinimiser: unable to set config: %w", err)
+	}
+
+	conf := edm.getConfig()
+
+	err = edm.setCryptopan(conf.CryptopanKey, conf.CryptopanKeySalt, conf.CryptopanAddressEntries)
 	if err != nil {
 		return nil, fmt.Errorf("newDnstapMinimiser: %w", err)
 	}
@@ -1198,9 +1326,9 @@ func newDnstapMinimiser(logger *slog.Logger, cryptopanKey string, cryptopanSalt 
 	// https://github.com/dnstap/golang-dnstap/blob/master/dnstap.go
 	edm.inputChannel = make(chan []byte, 32)
 	edm.log = logger
-	edm.debug = debug
-	edm.histogramSenderDisabled = histogramSenderDisabled
-	edm.mqttDisabled = mqttDisabled
+	edm.debug = conf.Debug
+	edm.histogramSenderDisabled = conf.DisableHistogramSender
+	edm.mqttDisabled = conf.DisableMQTT
 
 	edm.fsWatcher, err = fsnotify.NewWatcher()
 	if err != nil {
@@ -1216,7 +1344,7 @@ func newDnstapMinimiser(logger *slog.Logger, cryptopanKey string, cryptopanSalt 
 	// minimiser loop, otherwise the program can hang on shutdown.
 	edm.sessionWriterCh = make(chan *prevSessions, 100)
 	edm.histogramWriterCh = make(chan *wellKnownDomainsData, 100)
-	edm.newQnamePublisherCh = make(chan *protocols.EventsMqttMessageNewQnameJson, viper.GetInt("new-qname-buffer"))
+	edm.newQnamePublisherCh = make(chan *protocols.EventsMqttMessageNewQnameJson, conf.NewQnameBuffer)
 	edm.sessionCollectorCh = make(chan *sessionData, 100)
 
 	return edm, nil

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -60,17 +60,17 @@ import (
 var validate = validator.New(validator.WithRequiredStructEnabled())
 
 type config struct {
-	ConfigFile                string `mapstructure:"config-file"`
+	ConfigFile                string `mapstructure:"config-file" validate:"required"`
 	DisableSessionFiles       bool   `mapstructure:"disable-session-files"`
 	DisableHistogramSender    bool   `mapstructure:"disable-histogram-sender"`
 	DisableMQTT               bool   `mapstructure:"disable-mqtt"`
 	DisableMQTTFilequeue      bool   `mapstructure:"disable-mqtt-filequeue"`
-	InputUnix                 string `mapstructure:"input-unix"`
-	InputTCP                  string `mapstructure:"input-tcp"`
-	InputTLS                  string `mapstructure:"input-tls"`
-	InputTLSCertFile          string `mapstructure:"input-tls-cert-file"`
-	InputTLSKeyFile           string `mapstructure:"input-tls-key-file"`
-	InputTLSClientCAFile      string `mapstructure:"input-tls-client-ca-file"`
+	InputUnix                 string `mapstructure:"input-unix" validate:"required_without_all=InputTCP InputTLS,excluded_with_all=InputTCP InputTLS"`
+	InputTCP                  string `mapstructure:"input-tcp" validate:"required_without_all=InputUnix InputTLS,excluded_with_all=InputUnix InputTLS"`
+	InputTLS                  string `mapstructure:"input-tls" validate:"required_without_all=InputUnix InputTCP,excluded_with_all=InputUnix InputTCP"`
+	InputTLSCertFile          string `mapstructure:"input-tls-cert-file" validate:"required_with=InputTLS"`
+	InputTLSKeyFile           string `mapstructure:"input-tls-key-file" validate:"required_with=InputTLS"`
+	InputTLSClientCAFile      string `mapstructure:"input-tls-client-ca-file" validate:"required_with=InputTLS"`
 	CryptopanKey              string `mapstructure:"cryptopan-key" validate:"required"`
 	CryptopanKeySalt          string `mapstructure:"cryptopan-key-salt" validate:"required"`
 	WellKnownDomainsFile      string `mapstructure:"well-known-domains-file" validate:"required"`
@@ -78,24 +78,24 @@ type config struct {
 	IgnoredQuestionNamesFile  string `mapstructure:"ignored-question-names-file"`
 	DataDir                   string `mapstructure:"data-dir" validate:"required"`
 	MinimiserWorkers          int    `mapstructure:"minimiser-workers" validate:"required"`
-	MQTTSigningKeyFile        string `mapstructure:"mqtt-signing-key-file"`
-	MQTTSigningKeyID          string `mapstructure:"mqtt-signing-key-id"`
-	MQTTClientKeyFile         string `mapstructure:"mqtt-client-key-file"`
-	MQTTClientCertFile        string `mapstructure:"mqtt-client-cert-file"`
-	MQTTServer                string `mapstructure:"mqtt-server"`
-	MQTTTopic                 string `mapstructure:"mqtt-topic"`
-	MQTTClientID              string `mapstructure:"mqtt-client-id"`
+	MQTTSigningKeyFile        string `mapstructure:"mqtt-signing-key-file" validate:"required_without=DisableMQTT"`
+	MQTTSigningKeyID          string `mapstructure:"mqtt-signing-key-id" validate:"required_without=DisableMQTT"`
+	MQTTClientKeyFile         string `mapstructure:"mqtt-client-key-file" validate:"required_without=DisableMQTT"`
+	MQTTClientCertFile        string `mapstructure:"mqtt-client-cert-file" validate:"required_without=DisableMQTT"`
+	MQTTServer                string `mapstructure:"mqtt-server" validate:"required_without=DisableMQTT"`
+	MQTTTopic                 string `mapstructure:"mqtt-topic" validate:"required_without=DisableMQTT"`
+	MQTTClientID              string `mapstructure:"mqtt-client-id" validate:"required_without=DisableMQTT"`
 	MQTTCAFile                string `mapstructure:"mqtt-ca-file"`
-	MQTTKeepalive             uint16 `mapstructure:"mqtt-keepalive"`
+	MQTTKeepalive             uint16 `mapstructure:"mqtt-keepalive" validate:"required_without=DisableMQTT"`
 	QnameSeenEntries          int    `mapstructure:"qname-seen-entries"`
 	CryptopanAddressEntries   int    `mapstructure:"cryptopan-address-entries"`
 	NewQnameBuffer            int    `mapstructure:"newqname-buffer"`
 	HTTPCAFile                string `mapstructure:"http-ca-file"`
-	HTTPSigningKeyFile        string `mapstructure:"http-signing-key-file"`
-	HTTPSigningKeyID          string `mapstructure:"http-signing-key-id"`
-	HTTPClientKeyFile         string `mapstructure:"http-client-key-file"`
-	HTTPClientCertFile        string `mapstructure:"http-client-cert-file"`
-	HTTPURL                   string `mapstructure:"http-url"`
+	HTTPSigningKeyFile        string `mapstructure:"http-signing-key-file" validate:"required_without=DisableHistogramSender"`
+	HTTPSigningKeyID          string `mapstructure:"http-signing-key-id" validate:"required_without=DisableHistogramSender"`
+	HTTPClientKeyFile         string `mapstructure:"http-client-key-file" validate:"required_without=DisableHistogramSender"`
+	HTTPClientCertFile        string `mapstructure:"http-client-cert-file" validate:"required_without=DisableHistogramSender"`
+	HTTPURL                   string `mapstructure:"http-url" validate:"required_without=DisableHistogramSender"`
 	Debug                     bool   `mapstructure:"debug"`
 	DebugDnstapFilename       string `mapstructure:"debug-dnstap-filename"`
 	DebugEnableBlockProfiling bool   `mapstructure:"debug-enable-blockprofiling"`

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -18,7 +18,17 @@ import (
 	"github.com/spaolacci/murmur3"
 )
 
-var testDawg = flag.Bool("test-dawg", false, "perform tests requiring a well-known-domains.dawg file")
+var (
+	testDawg  = flag.Bool("test-dawg", false, "perform tests requiring a well-known-domains.dawg file")
+	defaultTC = testConfiger{
+		CryptopanKey:            "key1",
+		CryptopanKeySalt:        "aabbccddeeffgghh",
+		CryptopanAddressEntries: 10,
+		Debug:                   false,
+		DisableHistogramSender:  false,
+		DisableMQTT:             false,
+	}
+)
 
 func BenchmarkWKDTLookup(b *testing.B) {
 	if !*testDawg {
@@ -215,10 +225,7 @@ func TestIgnoredClientIPsValid(t *testing.T) {
 	discardLogger := slog.NewTextHandler(io.Discard, nil)
 	logger := slog.New(discardLogger)
 
-	cryptopanSalt := "aabbccddeeffgghh"
-	cryptopanCacheSize := 10
-
-	edm, err := newDnstapMinimiser(logger, "key1", cryptopanSalt, cryptopanCacheSize, false, false, false)
+	edm, err := newDnstapMinimiser(logger, defaultTC)
 	if err != nil {
 		t.Fatalf("unable to setup edm: %s", err)
 	}
@@ -400,10 +407,7 @@ func TestIgnoredClientIPsEmptyLinesComments(t *testing.T) {
 	discardLogger := slog.NewTextHandler(io.Discard, nil)
 	logger := slog.New(discardLogger)
 
-	cryptopanSalt := "aabbccddeeffgghh"
-	cryptopanCacheSize := 10
-
-	edm, err := newDnstapMinimiser(logger, "key1", cryptopanSalt, cryptopanCacheSize, false, false, false)
+	edm, err := newDnstapMinimiser(logger, defaultTC)
 	if err != nil {
 		t.Fatalf("unable to setup edm: %s", err)
 	}
@@ -468,10 +472,7 @@ func TestIgnoredClientIPsEmpty(t *testing.T) {
 	discardLogger := slog.NewTextHandler(io.Discard, nil)
 	logger := slog.New(discardLogger)
 
-	cryptopanSalt := "aabbccddeeffgghh"
-	cryptopanCacheSize := 10
-
-	edm, err := newDnstapMinimiser(logger, "key1", cryptopanSalt, cryptopanCacheSize, false, false, false)
+	edm, err := newDnstapMinimiser(logger, defaultTC)
 	if err != nil {
 		t.Fatalf("unable to setup edm: %s", err)
 	}
@@ -556,10 +557,7 @@ func TestIgnoredClientIPsUnset(t *testing.T) {
 	discardLogger := slog.NewTextHandler(io.Discard, nil)
 	logger := slog.New(discardLogger)
 
-	cryptopanSalt := "aabbccddeeffgghh"
-	cryptopanCacheSize := 10
-
-	edm, err := newDnstapMinimiser(logger, "key1", cryptopanSalt, cryptopanCacheSize, false, false, false)
+	edm, err := newDnstapMinimiser(logger, defaultTC)
 	if err != nil {
 		t.Fatalf("unable to setup edm: %s", err)
 	}
@@ -630,10 +628,7 @@ func TestIgnoredClientIPsInvalidClient(t *testing.T) {
 	discardLogger := slog.NewTextHandler(io.Discard, nil)
 	logger := slog.New(discardLogger)
 
-	cryptopanSalt := "aabbccddeeffgghh"
-	cryptopanCacheSize := 10
-
-	edm, err := newDnstapMinimiser(logger, "key1", cryptopanSalt, cryptopanCacheSize, false, false, false)
+	edm, err := newDnstapMinimiser(logger, defaultTC)
 	if err != nil {
 		t.Fatalf("unable to setup edm: %s", err)
 	}
@@ -678,10 +673,7 @@ func TestIgnoredQuestionNamesValid(t *testing.T) {
 	discardLogger := slog.NewTextHandler(io.Discard, nil)
 	logger := slog.New(discardLogger)
 
-	cryptopanSalt := "aabbccddeeffgghh"
-	cryptopanCacheSize := 10
-
-	edm, err := newDnstapMinimiser(logger, "key1", cryptopanSalt, cryptopanCacheSize, false, false, false)
+	edm, err := newDnstapMinimiser(logger, defaultTC)
 	if err != nil {
 		t.Fatalf("unable to setup edm: %s", err)
 	}
@@ -830,10 +822,7 @@ func TestIgnoredQuestionNamesEmpty(t *testing.T) {
 	discardLogger := slog.NewTextHandler(io.Discard, nil)
 	logger := slog.New(discardLogger)
 
-	cryptopanSalt := "aabbccddeeffgghh"
-	cryptopanCacheSize := 10
-
-	edm, err := newDnstapMinimiser(logger, "key1", cryptopanSalt, cryptopanCacheSize, false, false, false)
+	edm, err := newDnstapMinimiser(logger, defaultTC)
 	if err != nil {
 		t.Fatalf("unable to setup edm: %s", err)
 	}
@@ -911,10 +900,7 @@ func TestIgnoredQuestionNamesUnset(t *testing.T) {
 	discardLogger := slog.NewTextHandler(io.Discard, nil)
 	logger := slog.New(discardLogger)
 
-	cryptopanSalt := "aabbccddeeffgghh"
-	cryptopanCacheSize := 10
-
-	edm, err := newDnstapMinimiser(logger, "key1", cryptopanSalt, cryptopanCacheSize, false, false, false)
+	edm, err := newDnstapMinimiser(logger, defaultTC)
 	if err != nil {
 		t.Fatalf("unable to setup edm: %s", err)
 	}
@@ -1235,8 +1221,6 @@ func TestPseudonymiseDnstap(t *testing.T) {
 	discardLogger := slog.NewTextHandler(io.Discard, nil)
 	logger := slog.New(discardLogger)
 
-	cryptopanSalt := "aabbccddeeffgghh"
-
 	// The original addresses we want to pseudonymise
 	origQueryAddr4 := netip.MustParseAddr("198.51.100.20")
 	origRespAddr4 := netip.MustParseAddr("198.51.100.30")
@@ -1267,9 +1251,7 @@ func TestPseudonymiseDnstap(t *testing.T) {
 		},
 	}
 
-	cryptopanCacheSize := 10
-
-	edm, err := newDnstapMinimiser(logger, "key1", cryptopanSalt, cryptopanCacheSize, false, false, false)
+	edm, err := newDnstapMinimiser(logger, defaultTC)
 	if err != nil {
 		t.Fatalf("unable to setup edm: %s", err)
 	}
@@ -1392,7 +1374,7 @@ func TestPseudonymiseDnstap(t *testing.T) {
 	}
 
 	// Replace the cryptopan instance and verify we now get different pseudonymised results
-	err = edm.setCryptopan("key2", cryptopanSalt, cryptopanCacheSize)
+	err = edm.setCryptopan("key2", defaultTC.CryptopanKeySalt, defaultTC.CryptopanAddressEntries)
 	if err != nil {
 		t.Fatalf("unable to call edm.SetCryptopan: %s", err)
 	}
@@ -1484,7 +1466,7 @@ func TestPseudonymiseDnstap(t *testing.T) {
 	}
 
 	// Replace the cryptopan instance with uncached version and the first key and verify we get the same pseudonymised results
-	err = edm.setCryptopan("key1", cryptopanSalt, 0)
+	err = edm.setCryptopan(defaultTC.CryptopanKey, defaultTC.CryptopanKeySalt, 0)
 	if err != nil {
 		t.Fatalf("unable to call edm.SetCryptopan with 0 cache size: %s", err)
 	}
@@ -1560,15 +1542,11 @@ func BenchmarkPseudonymiseDnstapWithCache4(b *testing.B) {
 	discardLogger := slog.NewTextHandler(io.Discard, nil)
 	logger := slog.New(discardLogger)
 
-	cryptopanSalt := "aabbccddeeffgghh"
-
 	// The original addresses we want to pseudonymise
 	origQueryAddr4 := netip.MustParseAddr("198.51.100.20")
 	origRespAddr4 := netip.MustParseAddr("198.51.100.30")
 
-	cryptopanCacheSize := 10
-
-	edm, err := newDnstapMinimiser(logger, "key1", cryptopanSalt, cryptopanCacheSize, false, false, false)
+	edm, err := newDnstapMinimiser(logger, defaultTC)
 	if err != nil {
 		b.Fatalf("unable to setup edm: %s", err)
 	}
@@ -1593,15 +1571,14 @@ func BenchmarkPseudonymiseDnstapWithoutCache4(b *testing.B) {
 	discardLogger := slog.NewTextHandler(io.Discard, nil)
 	logger := slog.New(discardLogger)
 
-	cryptopanSalt := "aabbccddeeffgghh"
-
 	// The original addresses we want to pseudonymise
 	origQueryAddr4 := netip.MustParseAddr("198.51.100.20")
 	origRespAddr4 := netip.MustParseAddr("198.51.100.30")
 
-	cryptopanCacheSize := 0
+	uncachedTC := defaultTC
+	uncachedTC.CryptopanAddressEntries = 0
 
-	edm, err := newDnstapMinimiser(logger, "key1", cryptopanSalt, cryptopanCacheSize, false, false, false)
+	edm, err := newDnstapMinimiser(logger, uncachedTC)
 	if err != nil {
 		b.Fatalf("unable to setup edm: %s", err)
 	}
@@ -1626,15 +1603,11 @@ func BenchmarkPseudonymiseDnstapWithCache6(b *testing.B) {
 	discardLogger := slog.NewTextHandler(io.Discard, nil)
 	logger := slog.New(discardLogger)
 
-	cryptopanSalt := "aabbccddeeffgghh"
-
 	// The original addresses we want to pseudonymise
 	origQueryAddr6 := netip.MustParseAddr("2001:db8:1122:3344:5566:7788:99aa:bbcc")
 	origRespAddr6 := netip.MustParseAddr("2001:db8:1122:3344:5566:7788:99aa:ddee")
 
-	cryptopanCacheSize := 10
-
-	edm, err := newDnstapMinimiser(logger, "key1", cryptopanSalt, cryptopanCacheSize, false, false, false)
+	edm, err := newDnstapMinimiser(logger, defaultTC)
 	if err != nil {
 		b.Fatalf("unable to setup edm: %s", err)
 	}
@@ -1659,15 +1632,14 @@ func BenchmarkPseudonymiseDnstapWithoutCache6(b *testing.B) {
 	discardLogger := slog.NewTextHandler(io.Discard, nil)
 	logger := slog.New(discardLogger)
 
-	cryptopanSalt := "aabbccddeeffgghh"
-
 	// The original addresses we want to pseudonymise
 	origQueryAddr6 := netip.MustParseAddr("2001:db8:1122:3344:5566:7788:99aa:bbcc")
 	origRespAddr6 := netip.MustParseAddr("2001:db8:1122:3344:5566:7788:99aa:ddee")
 
-	cryptopanCacheSize := 0
+	uncachedTC := defaultTC
+	uncachedTC.CryptopanAddressEntries = 0
 
-	edm, err := newDnstapMinimiser(logger, "key1", cryptopanSalt, cryptopanCacheSize, false, false, false)
+	edm, err := newDnstapMinimiser(logger, uncachedTC)
 	if err != nil {
 		b.Fatalf("unable to setup edm: %s", err)
 	}


### PR DESCRIPTION
Reading config via viper.GetString("foo"), viper.GetInt("bar") etc is error prone as the string being looked for can easily be misspelled which will not be noticed at compile time. Now we unmarshal the viper config to a config struct instead and this way a program that tries to use an unknown struct field will not even compile which is nice.

This way we can also more easily do validation of the contents of the config which has been added with the validator package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated core dependencies to enhance validation and localization capabilities.
- **Refactor**
	- Revamped configuration management for improved error handling, thread safety, and overall robustness.
- **Tests**
	- Consolidated test configurations into a unified structure for greater consistency and easier maintenance.

These changes bring improved stability and reliability to the application, ensuring a smoother experience behind the scenes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->