### PR TITLE
Add static backoff time on erroring sends

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1946,6 +1946,8 @@ func (edm *dnstapMinimiser) histogramSender(outboxDir string, sentDir string, wg
 
 	edm.log.Info("histogramSender: starting")
 
+	backoffDuration := time.Second * 15
+
 	// We will scan the outbox directory each tick for histogram parquet
 	// files to send
 	ticker := time.NewTicker(time.Second * 10)
@@ -1980,7 +1982,8 @@ timerLoop:
 					absPathSent := filepath.Join(sentDir, dirEntry.Name())
 					err = edm.aggregSender.send(absPath, startTS, duration)
 					if err != nil {
-						edm.log.Error("histogramSender: unable to send histogram file", "error", err)
+						edm.log.Error("histogramSender: unable to send histogram file", "error", err, "backoff_duration", backoffDuration)
+						time.Sleep(backoffDuration)
 						continue
 					}
 					err = edm.renameFile(absPath, absPathSent)


### PR DESCRIPTION
Should ease the load on aggrec if something is wrong with the sending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling during histogram data processing by introducing a delay mechanism after failed attempts. This improves the system's stability and resilience against transient errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->