### PR TITLE
Give golangci-lint more time to run in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,5 +20,6 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.60
+          args: --timeout=5m
       - name: Build
         run: make build


### PR DESCRIPTION
For some reason it randomly takes longer than the default 1m to run this in CI, increase it some to make it less likely to timeout.

Error seen in workflow:
```
Running [/home/runner/golangci-lint-1.60.3-linux-amd64/golangci-lint run] in [/home/runner/work/edm/edm] ...
  level=error msg="Timeout exceeded: try increasing it by passing --timeout option"

  Error: golangci-lint exit with code 4
  Ran golangci-lint in 60308ms
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced internal code quality checks by setting a stricter time limit, contributing to more efficient and predictable build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->