### PR TITLE
Add overflow handling for timestamps and ports

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1750,13 +1750,25 @@ func (edm *dnstapMinimiser) newSession(dt *dnstap.Dnstap, msg *dns.Msg, isQuery 
 	sd := &sessionData{}
 
 	if dt.Message.QueryPort != nil {
-		qp := int32(*dt.Message.QueryPort) // #nosec G115 -- QueryPort is defined as 16-bit number and is used in parquet field with type=INT32, convertedType=UINT_16
-		sd.SourcePort = &qp
+		if *dt.Message.QueryPort > math.MaxInt32 {
+			edm.log.Error("dt.Message.QueryPort is too large for int32, setting port 0")
+			var qp int32
+			sd.SourcePort = &qp
+		} else {
+			qp := int32(*dt.Message.QueryPort) // #nosec G115 -- QueryPort is defined as 16-bit number and is used in parquet field with type=INT32, convertedType=UINT_16, https://github.com/securego/gosec/issues/1212#issuecomment-2739574884
+			sd.SourcePort = &qp
+		}
 	}
 
 	if dt.Message.ResponsePort != nil {
-		rp := int32(*dt.Message.ResponsePort) // #nosec G115 -- ResponsePort is defined as 16-bit number and is used in parquet field with type=INT32, convertedType=UINT_16
-		sd.DestPort = &rp
+		if *dt.Message.ResponsePort > math.MaxInt32 {
+			edm.log.Error("dt.Message.ResponsePort is too large for int32, setting port 0")
+			var rp int32
+			sd.DestPort = &rp
+		} else {
+			rp := int32(*dt.Message.ResponsePort) // #nosec G115 -- ResponsePort is defined as 16-bit number and is used in parquet field with type=INT32, convertedType=UINT_16, https://github.com/securego/gosec/issues/1212#issuecomment-2739574884
+			sd.DestPort = &rp
+		}
 	}
 
 	edm.setSessionLabels(dns.SplitDomainName(msg.Question[0].Name), labelLimit, sd)
@@ -2050,14 +2062,24 @@ func (edm *dnstapMinimiser) parsePacket(dt *dnstap.Dnstap, isQuery bool) (*dns.M
 			edm.log.Error("unable to unpack query message", "error", err, "query_address", queryAddress, "response_address", responseAddress)
 			msg = nil
 		}
-		t = time.Unix(int64(*dt.Message.QueryTimeSec), int64(*dt.Message.QueryTimeNsec)).UTC() // #nosec G115 -- Overflowing the int64 would result in interesting timestamps but not much else
+		if *dt.Message.QueryTimeSec > math.MaxInt64 {
+			edm.log.Error("dt.Message.QueryTimeSec is too large for int64, setting time to 0")
+			*dt.Message.QueryTimeSec = 0
+			*dt.Message.QueryTimeNsec = 0
+		}
+		t = time.Unix(int64(*dt.Message.QueryTimeSec), int64(*dt.Message.QueryTimeNsec)).UTC() // #nosec G115 -- Will be zeroed out above if too large, https://github.com/securego/gosec/issues/1212#issuecomment-2739574884
 	} else {
 		err = msg.Unpack(dt.Message.ResponseMessage)
 		if err != nil {
 			edm.log.Error("unable to unpack response message", "error", err, "query_address", queryAddress, "response_address", responseAddress)
 			msg = nil
 		}
-		t = time.Unix(int64(*dt.Message.ResponseTimeSec), int64(*dt.Message.ResponseTimeNsec)).UTC() // #nosec G115 -- Overflowing the int64 would result in interesting timestamps but not much else
+		if *dt.Message.ResponseTimeSec > math.MaxInt64 {
+			edm.log.Error("dt.Message.ResponseTimeSec is too large for int64, setting time to 0")
+			*dt.Message.ResponseTimeSec = 0
+			*dt.Message.ResponseTimeNsec = 0
+		}
+		t = time.Unix(int64(*dt.Message.ResponseTimeSec), int64(*dt.Message.ResponseTimeNsec)).UTC() // #nosec G115 -- Will be zeroed out above if too large, https://github.com/securego/gosec/issues/1212#issuecomment-2739574884
 	}
 
 	return msg, t

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1751,7 +1751,7 @@ func (edm *dnstapMinimiser) newSession(dt *dnstap.Dnstap, msg *dns.Msg, isQuery 
 
 	if dt.Message.QueryPort != nil {
 		if *dt.Message.QueryPort > math.MaxInt32 {
-			edm.log.Error("dt.Message.QueryPort is too large for int32, setting port 0")
+			edm.log.Error("dt.Message.QueryPort is too large for int32, setting port to 0", "value", *dt.Message.QueryPort)
 			var qp int32
 			sd.SourcePort = &qp
 		} else {
@@ -1762,7 +1762,7 @@ func (edm *dnstapMinimiser) newSession(dt *dnstap.Dnstap, msg *dns.Msg, isQuery 
 
 	if dt.Message.ResponsePort != nil {
 		if *dt.Message.ResponsePort > math.MaxInt32 {
-			edm.log.Error("dt.Message.ResponsePort is too large for int32, setting port 0")
+			edm.log.Error("dt.Message.ResponsePort is too large for int32, setting port to 0", "value", *dt.Message.ResponsePort)
 			var rp int32
 			sd.DestPort = &rp
 		} else {
@@ -2063,7 +2063,7 @@ func (edm *dnstapMinimiser) parsePacket(dt *dnstap.Dnstap, isQuery bool) (*dns.M
 			msg = nil
 		}
 		if *dt.Message.QueryTimeSec > math.MaxInt64 {
-			edm.log.Error("dt.Message.QueryTimeSec is too large for int64, setting time to 0")
+			edm.log.Error("dt.Message.QueryTimeSec is too large for int64, setting time to 0", "value", *dt.Message.QueryTimeSec)
 			*dt.Message.QueryTimeSec = 0
 			*dt.Message.QueryTimeNsec = 0
 		}
@@ -2075,7 +2075,7 @@ func (edm *dnstapMinimiser) parsePacket(dt *dnstap.Dnstap, isQuery bool) (*dns.M
 			msg = nil
 		}
 		if *dt.Message.ResponseTimeSec > math.MaxInt64 {
-			edm.log.Error("dt.Message.ResponseTimeSec is too large for int64, setting time to 0")
+			edm.log.Error("dt.Message.ResponseTimeSec is too large for int64, setting time to 0", "value", *dt.Message.ResponseTimeSec)
 			*dt.Message.ResponseTimeSec = 0
 			*dt.Message.ResponseTimeNsec = 0
 		}


### PR DESCRIPTION
If the input data is too large for the target type log an error and set the target data to 0.

The added checking should remove the need for te #nosec G115 comment but is seems the nested dnstap struct is causing issues for gosec, see the linked issue comment for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced data validation for network communication fields to gracefully handle out-of-range port and time values, improving system stability and preventing unexpected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->