### PR TITLE
Stop requiring an input flag

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -38,7 +38,6 @@ func init() {
 	runCmd.Flags().String("input-unix", "", "create unix socket for reading dnstap (e.g. /var/lib/unbound/dnstap.sock)")
 	runCmd.Flags().String("input-tcp", "", "create TCP socket for reading dnstap (e.g. '127.0.0.1:53535')")
 	runCmd.Flags().String("input-tls", "", "create TLS TCP socket for reading dnstap (e.g. '127.0.0.1:53535')")
-	runCmd.MarkFlagsOneRequired("input-unix", "input-tcp", "input-tls")
 	runCmd.MarkFlagsMutuallyExclusive("input-unix", "input-tcp", "input-tls")
 
 	runCmd.Flags().String("input-tls-cert-file", "", "file containing cert used for TLS TCP socket")

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -64,9 +64,9 @@ type config struct {
 	DisableHistogramSender    bool   `mapstructure:"disable-histogram-sender"`
 	DisableMQTT               bool   `mapstructure:"disable-mqtt"`
 	DisableMQTTFilequeue      bool   `mapstructure:"disable-mqtt-filequeue"`
-	InputUnix                 string `mapstructure:"input-unix" validate:"required_without_all=InputTCP InputTLS,excluded_with_all=InputTCP InputTLS"`
-	InputTCP                  string `mapstructure:"input-tcp" validate:"required_without_all=InputUnix InputTLS,excluded_with_all=InputUnix InputTLS"`
-	InputTLS                  string `mapstructure:"input-tls" validate:"required_without_all=InputUnix InputTCP,excluded_with_all=InputUnix InputTCP"`
+	InputUnix                 string `mapstructure:"input-unix" validate:"required_without_all=InputTCP InputTLS,excluded_with=InputTCP InputTLS"`
+	InputTCP                  string `mapstructure:"input-tcp" validate:"required_without_all=InputUnix InputTLS,excluded_with=InputUnix InputTLS"`
+	InputTLS                  string `mapstructure:"input-tls" validate:"required_without_all=InputUnix InputTCP,excluded_with=InputUnix InputTCP"`
 	InputTLSCertFile          string `mapstructure:"input-tls-cert-file" validate:"required_with=InputTLS"`
 	InputTLSKeyFile           string `mapstructure:"input-tls-key-file" validate:"required_with=InputTLS"`
 	InputTLSClientCAFile      string `mapstructure:"input-tls-client-ca-file" validate:"required_with=InputTLS"`


### PR DESCRIPTION
Since we are now moving in the direction of using a config file we want to be able to control inputs from the config instead.

There is already validation for the resulting conf struct to catch duplicate inputs so just remove the requirement from the flags. While here replace "exluded_with_all" with "exluded_with", a field must no be set if _any_ of the other fields are set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Allowed commands to run without specifying an input flag while still ensuring that only one input option is selected at a time.
  - Revised validation rules for input options, enhancing clarity and preventing conflicting inputs.
  - These improvements provide greater flexibility and a smoother experience when using command-line options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->