### PR TITLE
Separate out pprof server from prometheus endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,15 @@ query name has been seen before or not. The key-value store being used is
 
 ## Observability
 
-`edm` exposes [prometheus](https://prometheus.io) metrics and
-go [pprof](https://pkg.go.dev/net/http/pprof) profiling data via HTTP listener
-at `127.0.0.1:2112`.
-To look at prometheus current metrics:
+`edm` exposes [prometheus](https://prometheus.io) metrics at `127.0.0.1:2112`
+and go [pprof](https://pkg.go.dev/net/http/pprof) profiling data at `127.0.0.1:6060`.
+To look at prometheus metrics:
 ```
 curl 127.0.0.1:2112/metrics
 ```
 There are multiple types of profiling data available, here is a CPU-centric example:
 ```
-go tool pprof http://127.0.0.1:2112/debug/pprof/profile?seconds=30
+go tool pprof http://127.0.0.1:6060/debug/pprof/profile?seconds=30
 ```
 
 ## Development


### PR DESCRIPTION
It seems like a good idea to keep the two endpoints separate as you might want to give some monitoring system access to prometheus metrics without also giving access to pprof data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Launched an enhanced performance monitoring endpoint to improve profiling capabilities.
  - Optimized the configuration for performance data reporting, resulting in more responsive monitoring.

- **Documentation**
  - Updated observability guidelines with revised instructions for accessing profiling and performance metrics.
  - Modified CPU profiling command details to align with the latest monitoring setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->