### PR TITLE
modify specfile to work with RHEL and SUSE

### DIFF
--- a/rpm/tapir-edm.spec.in
+++ b/rpm/tapir-edm.spec.in
@@ -33,7 +33,7 @@ DNSTAPIR EDGE DNSTAP Minimiser
 
 %{!?_unitdir: %define _unitdir /usr/lib/systemd/system/}
 %{!?_sysusersdir: %define _sysusersdir /usr/lib/sysusers.d/}
-%{!?_localstatedir: %define _localstatedir /var/}
+%{!?_localstatedir: %define _localstatedir /var/lib}
 
 %prep
 %setup -n %{name}
@@ -51,7 +51,7 @@ install -p -m 0755 %{name} %{buildroot}%{_bindir}/%{name}
 install -m 0644 %{SOURCE1} %{buildroot}%{_unitdir}
 install -m 0664 -D %{SOURCE2} %{buildroot}%{_sysconfdir}/dnstapir/edm/well-known-domains.dawg
 install -m 0664 -D %{SOURCE3} %{buildroot}%{_sysconfdir}/dnstapir/edm/ignored.dawg
-install -m 0664 -D %{SOURCE3} %{buildroot}%{_sysconfdir}/dnstapir/edm/ignored-ips
+install -m 0664 -D %{SOURCE4} %{buildroot}%{_sysconfdir}/dnstapir/edm/ignored-ips
 
 %files
 %license LICENSE

--- a/rpm/tapir-edm.spec.in
+++ b/rpm/tapir-edm.spec.in
@@ -12,9 +12,15 @@ Source2:       well-known-domains.dawg
 Source3:       ignored.dawg
 Source4:       ignored-ips
 BuildRequires: git
-BuildRequires: golang
+%if 0%{?suse_version}
+BuildRequires: go
 %if 0%{?suse_version} >= 1500
+%ifarch x86_64 aarch64
 BuildRequires: go-race
+%endif
+%endif
+%else
+BuildRequires: golang
 %endif
 
 %description

--- a/rpm/tapir-edm.spec.in
+++ b/rpm/tapir-edm.spec.in
@@ -13,9 +13,17 @@ Source3:       ignored.dawg
 Source4:       ignored-ips
 BuildRequires: git
 BuildRequires: golang
+%if 0%{?suse_version} >= 1500
+BuildRequires: go-race
+%endif
 
 %description
 DNSTAPIR EDGE DNSTAP Minimiser
+
+# Disable building of debug packages for RHEL (we include symbols per default)
+%if 0%{?rhel} >= 9
+%global debug_package %{nil}
+%endif
 
 %{!?_unitdir: %define _unitdir /usr/lib/systemd/system/}
 %{!?_sysusersdir: %define _sysusersdir /usr/lib/sysusers.d/}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated RPM packaging to apply distribution-specific conditions: SUSE 15+ builds include additional Go tooling and race detector on supported architectures; RHEL 9+ builds disable debug subpackages, producing slimmer packages.
  - Default local state directory set to /var/lib (instead of /var/), and packaging install references adjusted; no runtime logic changes expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->