### PR TITLE
Repair HLL defaults

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -481,7 +481,8 @@ func setHllDefaults() error {
 	err := hll.Defaults(hll.Settings{
 		Log2m:             10,
 		Regwidth:          4,
-		ExplicitThreshold: hll.AutoExplicitThreshold, SparseEnabled: true,
+		ExplicitThreshold: 0,
+		SparseEnabled:     true,
 	})
 
 	return err


### PR DESCRIPTION
Set ExplicitThreshold to 0 as expected.

This was originally done in rev 12a603e0ce8792b1c3b0924c94bf72272277b936

Setting was lost by mistake in 2dc60ac28e8bdfbfd6acf8f3f40e37823e839989

While here fix indentation.