### PR TITLE
Fixed an error when pointing out database dir in packaging

### DIFF
--- a/rpm/tapir-edm.spec.in
+++ b/rpm/tapir-edm.spec.in
@@ -33,7 +33,8 @@ DNSTAPIR EDGE DNSTAP Minimiser
 
 %{!?_unitdir: %define _unitdir /usr/lib/systemd/system/}
 %{!?_sysusersdir: %define _sysusersdir /usr/lib/sysusers.d/}
-%{!?_localstatedir: %define _localstatedir /var/}
+%{!?_localstatedir: %define _localstatedir /var}
+%{!?_sharedstatedir: %define _sharedstatedir %{_localstatedir}/lib}
 
 %prep
 %setup -n %{name}
@@ -45,7 +46,7 @@ make build
 mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_unitdir}
 mkdir -p %{buildroot}%{_sysconfdir}/dnstapir/edm
-mkdir -p %{buildroot}%{_localstatedir}/lib/edm/pebble
+mkdir -p %{buildroot}%{_sharedstatedir}/edm/pebble
 
 install -p -m 0755 %{name} %{buildroot}%{_bindir}/%{name}
 install -m 0644 %{SOURCE1} %{buildroot}%{_unitdir}
@@ -57,8 +58,8 @@ install -m 0664 -D %{SOURCE4} %{buildroot}%{_sysconfdir}/dnstapir/edm/ignored-ip
 %license LICENSE
 
 %attr(0770,tapir-edm,dnstapir) %dir %{_sysconfdir}/dnstapir/edm
-%attr(0770,tapir-edm,dnstapir) %dir %{_localstatedir}/lib/edm
-%attr(0770,tapir-edm,dnstapir) %dir %{_localstatedir}/lib/edm/pebble
+%attr(0770,tapir-edm,dnstapir) %dir %{_sharedstatedir}/edm
+%attr(0770,tapir-edm,dnstapir) %dir %{_sharedstatedir}/edm/pebble
 
 %attr(0755,tapir-edm,dnstapir) %{_bindir}/%{name}
 %attr(0644,tapir-edm,dnstapir) %{_unitdir}/tapir-edm.service


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.

- Chores
  - Standardized EDM data locations to a shared system state directory (data paths moved accordingly).
  - Updated default local state root from /var/lib to /var to align with the shared-state layout.
  - Adjusted configuration file ownership to be group-managed (dnstapir) with no specific user owner.

- Notes
  - No functional changes; verify permissions if tooling depended on a specific file owner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->