### PR TITLE
Fix some naming

### DIFF
--- a/rpm/SOURCES/tapir-edm.service
+++ b/rpm/SOURCES/tapir-edm.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=DNSTAPIR EDGE DNSTAP Minimiser
+Description=TAPIR Edge DNSTAP Minimiser
 
 [Service]
 Type=simple

--- a/rpm/tapir-edm.spec.in
+++ b/rpm/tapir-edm.spec.in
@@ -3,7 +3,7 @@ Name:          tapir-edm
 Version:       @@VERSION@@
 Release:       1%{?dist}
 Group:         dnstapir/edge
-Summary:       DNSTAPIR EDGE DNSTAPR Minimiser
+Summary:       TAPIR Edge DNSTAP Minimiser
 License:       BSD-2-Clause
 URL:           https://www.github.com/dnstapir/edm
 Source0:       %{name}.tar.gz
@@ -24,7 +24,7 @@ BuildRequires: golang
 %endif
 
 %description
-DNSTAPIR EDGE DNSTAP Minimiser
+TAPIR Edge DNSTAP Minimiser
 
 # Disable building of debug packages for RHEL (we include symbols per default)
 %if 0%{?rhel} >= 9


### PR DESCRIPTION
EDGE -> Edge

Also to match the package name use the shorthand "TAPIR" instead of DNSTAPIR in Description/Summary (which otherwise should be written "DNS TAPIR").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated product naming and descriptions to “TAPIR Edge DNSTAP Minimiser” in service and package metadata. No functional changes.

- Chores
  - Disabled automatic debug package generation for RHEL 9+ builds to streamline packaging.
  - Ensured service unit description reflects new naming, with no impact on startup, user/group, or execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->