### PR TITLE
Set GOTOOLCHAIN=auto in build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ all:
 container:
 	KO_DOCKER_REPO=ko.local ko build --bare
 
+build: export GOTOOLCHAIN=auto
 build:
 	go mod download
 ifeq "$(run_tests)" "yes"


### PR DESCRIPTION
We have problems with builds in Copr where the available golang package is not new enough on some distros:
```
+ make build
go mod download
go: go.mod requires go >= 1.25.1 (running go 1.25.0; GOTOOLCHAIN=local)
make: *** [Makefile:25: build] Error 1
```

It seems e.g. Fedora changes the default GOTOOLCHAIN from "auto" to "local" so that the distribution-packaged Go toolchain is always used. Change it back to see if we more easily can support more distros this way.