### PR TITLE
Include "v" prefix in empty version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OUTPUT=tapir-edm
 SPECFILE_IN:=rpm/tapir-edm.spec.in
 SPECFILE_OUT:=rpm/SPECS/tapir-edm.spec
 
-VERSION:=$$(git describe --tags --abbrev=0 2> /dev/null || echo "0.0.0")
+VERSION:=$$(git describe --tags --abbrev=0 2> /dev/null || echo "v0.0.0")
 SHA:=$$(git describe --dirty=+WiP --always)
 DATE:=$$(date +%Y%m%d)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the default app version format to include a “v” prefix when no release tags are available (e.g., v0.0.0).
  * Ensures consistent version labeling across builds, logs, and artifact names, improving clarity for users and tooling that expects a leading “v”.
  * Behavior remains unchanged when release tags are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->