### PR TITLE
Set GOSUMDB for "make build"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ all:
 container:
 	KO_DOCKER_REPO=ko.local ko build --bare
 
+build: export GOSUMDB=sum.golang.org
 build: export GOTOOLCHAIN=auto
 build:
 	go mod download


### PR DESCRIPTION
It seems Copr build on Fedora 42 was still not happy after adding GOTOOLCHAIN.

Error seen:
```
go: downloading go1.25.1 (linux/amd64)
go: download go1.25.1: golang.org/toolchain@v0.0.1-go1.25.1.linux-amd64: verifying module: checksum database disabled by GOSUMDB=off
```