### PR TITLE
Disable debug packages for Fedora 42 and below

### DIFF
--- a/rpm/tapir-edm.spec.in
+++ b/rpm/tapir-edm.spec.in
@@ -27,7 +27,8 @@ BuildRequires: golang
 TAPIR Edge DNSTAP Minimiser
 
 # Disable building of debug packages for RHEL (we include symbols per default)
-%if 0%{?rhel} >= 9
+# ... also disable it for Fedora 42 and below to fix builds
+%if 0%{?rhel} >= 9 || 0%{?fedora} <= 42
 %global debug_package %{nil}
 %endif
 


### PR DESCRIPTION
The build still fails, errors seen:
```
[...]
Extracting debug info from 1 files
debugedit: /builddir/build/BUILD/tapir-edm-v0.0.0_20250922.bbd7f68-build/BUILDROOT/usr/bin/tapir-edm: Unsupported .debug_line directory 0 path DW_FORM_0x8
debugedit: /builddir/build/BUILD/tapir-edm-v0.0.0_20250922.bbd7f68-build/BUILDROOT/usr/bin/tapir-edm: Unsupported .debug_line directory 0 path DW_FORM_0x8
debugedit: /builddir/build/BUILD/tapir-edm-v0.0.0_20250922.bbd7f68-build/BUILDROOT/usr/bin/tapir-edm: Unsupported .debug_line directory 0 path DW_FORM_0x8
debugedit: /builddir/build/BUILD/tapir-edm-v0.0.0_20250922.bbd7f68-build/BUILDROOT/usr/bin/tapir-edm: Unsupported .debug_line directory 0 path DW_FORM_0x8
[...]
RPM build errors:
error: Empty %files file /builddir/build/BUILD/tapir-edm-v0.0.0_20250922.bbd7f68-build/tapir-edm/debugsourcefiles.list
    %source_date_epoch_from_changelog is set, but %changelog has no entries to take a date from
    Empty %files file /builddir/build/BUILD/tapir-edm-v0.0.0_20250922.bbd7f68-build/tapir-edm/debugsourcefiles.list
```

This might be related to go 1.25 enabling DWARF 5. That can be disabled with GOEXPERIMENT=nodwarf5 but lets see if we can skip debug packags to ignore this instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated packaging to disable debug packages on RHEL 9+ and Fedora 42 and earlier. This aligns behavior across supported platforms and reduces download size and install overhead for those environments. Runtime behavior and application features are unchanged.
  - No changes to public interfaces or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->