### PR TITLE
Handle tags in container builds

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,13 +8,15 @@ on:
       - "main"
     types:
       - completed
-  push:
-    tags:
-      - "v*.*.*"
+  release:
+    types:
+      - published
 
 jobs:
-  container:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+  tagged-container:
+    if: >-
+      ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+          (github.event_name == 'release'      && github.event.action == 'published') }}
     name: Build and push container
     runs-on: ubuntu-latest
     permissions:
@@ -23,8 +25,20 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/metadata-action@v5
+        name: Extract metadata
+        id: meta
+        with:
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
       - uses: actions/setup-go@v5
         with:
           go-version: '1.25.1'
       - uses: ko-build/setup-ko@v0.7
-      - run: ko build --bare
+      - run: ko build --bare --tags "$(printf '%s' "${{ steps.meta.outputs.tags }}" | tr '\n' ',')"
+        name: Build and push
+        env:
+          VERSION: ${{ github.event_name == 'release' && github.ref_name || github.sha }}


### PR DESCRIPTION
Inspired by nodeman workflows, make it so we are prepared to build containers based on release tags.

The binary will have either the release tag or the full revision sha as the version it includes in logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Container images now publish automatically on new releases and after successful builds.
  - Images include multiple tags, such as semantic version tags and “latest”; non-release builds use a short commit-based version.
- Chores
  - Updated automation to extract version metadata and apply multiple tags during image build and push.
  - Unified logic to handle both release and build-completion triggers for consistent image publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->