### PR TITLE
Use manually specified container registry when cleaning

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -45,4 +45,5 @@ jobs:
       - name: Delete untagged containers
         uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4
         with:
+          repository: edm/dnstapir-edm
           delete-untagged: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container cleanup configuration in the CI/CD pipeline to explicitly specify the target repository for untagged container removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->