### PR TITLE
fix(config): allow optional TLS client CA

### DIFF
--- a/pkg/runner/config_validation_test.go
+++ b/pkg/runner/config_validation_test.go
@@ -1,0 +1,30 @@
+package runner
+
+import "testing"
+
+func TestConfigValidationAllowsTLSWithoutClientCA(t *testing.T) {
+	conf := validConfigForValidation()
+	conf.InputUnix = ""
+	conf.InputTLS = "127.0.0.1:53535"
+	conf.InputTLSCertFile = "server-cert.pem"
+	conf.InputTLSKeyFile = "server-key.pem"
+
+	if err := validate.Struct(conf); err != nil {
+		t.Fatalf("TLS input with server cert/key and no client CA should be valid: %s", err)
+	}
+}
+
+func validConfigForValidation() config {
+	return config{
+		ConfigFile:                    "dnstapir-edm.toml",
+		DisableHistogramSender:        true,
+		DisableMQTT:                   true,
+		InputUnix:                     "/tmp/dnstapir-edm.sock",
+		CryptopanKey:                  "mysecret",
+		CryptopanKeySalt:              "edm-kdf-salt-val",
+		WellKnownDomainsFile:          "well-known-domains.dawg",
+		HistogramHLLExplicitThreshold: 20,
+		DataDir:                       "/var/lib/dnstapir/edm",
+		MinimiserWorkers:              1,
+	}
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -75,7 +75,7 @@ type config struct {
 	InputTLS                      string `mapstructure:"input-tls" validate:"required_without_all=InputUnix InputTCP,excluded_with=InputUnix InputTCP"`
 	InputTLSCertFile              string `mapstructure:"input-tls-cert-file" validate:"required_with=InputTLS"`
 	InputTLSKeyFile               string `mapstructure:"input-tls-key-file" validate:"required_with=InputTLS"`
-	InputTLSClientCAFile          string `mapstructure:"input-tls-client-ca-file" validate:"required_with=InputTLS"`
+	InputTLSClientCAFile          string `mapstructure:"input-tls-client-ca-file"`
 	CryptopanKey                  string `mapstructure:"cryptopan-key" validate:"required" reload:"true"`
 	CryptopanKeySalt              string `mapstructure:"cryptopan-key-salt" validate:"required" reload:"true"`
 	WellKnownDomainsFile          string `mapstructure:"well-known-domains-file" validate:"required"`


### PR DESCRIPTION
## Summary
- allow TLS listener configs to omit a client CA file
- keep cert/key validation intact when TLS input is enabled
- add focused validation coverage

## Tests
- go test ./pkg/runner ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TLS configuration no longer requires a client CA file to be specified.

* **Tests**
  * Added unit tests validating TLS configuration behavior without client CA requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->