### PR TITLE
fix(protocols): tolerate empty question events

### DIFF
--- a/pkg/protocols/protocols.go
+++ b/pkg/protocols/protocols.go
@@ -95,20 +95,28 @@ func bitsFromMsg(dns *dns.Msg) uint16 {
 	return bits
 }
 
+// NewQnameEvent constructs a NewQnameJSON event from a DNS message and a
+// timestamp. If the Question section is empty the returned event will have
+// an empty Qname, nil Qtype and nil Qclass, but other header-derived fields
+// will still be populated.
 func NewQnameEvent(msg *dns.Msg, ts time.Time) NewQnameJSON {
 	bits := bitsFromMsg(msg)
 	flags := int(bits)
 
-	qType := int(msg.Question[0].Qtype)
-	qClass := int(msg.Question[0].Qclass)
-
-	return NewQnameJSON{
+	event := NewQnameJSON{
 		Type:      NewQnameJSONType,
-		Qname:     msg.Question[0].Name,
-		Qtype:     &qType,
-		Qclass:    &qClass,
 		Timestamp: &ts,
 		Flags:     &flags,
 		Version:   NewQnameJSONVersion,
 	}
+
+	if len(msg.Question) > 0 {
+		qType := int(msg.Question[0].Qtype)
+		qClass := int(msg.Question[0].Qclass)
+		event.Qname = msg.Question[0].Name
+		event.Qtype = &qType
+		event.Qclass = &qClass
+	}
+
+	return event
 }

--- a/pkg/protocols/protocols_test.go
+++ b/pkg/protocols/protocols_test.go
@@ -60,3 +60,39 @@ func TestNewQnameEvent(t *testing.T) {
 		t.Fatalf("Flags = %v, want %d", got.Flags, _RD)
 	}
 }
+
+func TestNewQnameEventEmptyQuestion(t *testing.T) {
+	msg := new(dns.Msg)
+
+	ts := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("NewQnameEvent panicked with empty Question section: %v", r)
+		}
+	}()
+
+	event := NewQnameEvent(msg, ts)
+
+	if event.Qname != "" {
+		t.Fatalf("Qname have: %q want: %q", event.Qname, "")
+	}
+	if event.Qtype != nil {
+		t.Fatalf("Qtype have: %v want: nil", event.Qtype)
+	}
+	if event.Qclass != nil {
+		t.Fatalf("Qclass have: %v want: nil", event.Qclass)
+	}
+	if event.Type != NewQnameJSONType {
+		t.Fatalf("Type have: %q want: %q", event.Type, NewQnameJSONType)
+	}
+	if event.Version != NewQnameJSONVersion {
+		t.Fatalf("Version have: %d want: %d", event.Version, NewQnameJSONVersion)
+	}
+	if event.Timestamp == nil || !event.Timestamp.Equal(ts) {
+		t.Fatalf("Timestamp have: %v want: %v", event.Timestamp, ts)
+	}
+	if event.Flags == nil {
+		t.Fatal("Flags have: nil want: non-nil")
+	}
+}


### PR DESCRIPTION
## Summary
- make NewQnameEvent safe for DNS messages with no questions
- preserve header-derived fields while leaving qname/qtype/qclass empty
- update the doc comment to match the permissive behavior

## Tests
- go test ./pkg/protocols ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when processing DNS messages that contain an empty question section; related event fields now default sensibly instead of causing errors.

* **Tests**
  * Added unit test coverage to verify safe handling of DNS messages with empty question sections and to ensure produced events contain expected metadata and sensible defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->