### PR TITLE
fix(mqtt): normalize server URLs

### DIFF
--- a/pkg/runner/mqtt.go
+++ b/pkg/runner/mqtt.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/eclipse/paho.golang/autopaho"
@@ -56,9 +57,9 @@ type mqttConnectionManager interface {
 }
 
 func (edm *dnstapMinimiser) newAutoPahoClientConfig(caCertPool *x509.CertPool, server string, clientID string, mqttKeepAlive uint16, localFileQueue *file.Queue) (autopaho.ClientConfig, error) {
-	u, err := url.Parse(server)
+	u, err := parseMQTTServerURL(server)
 	if err != nil {
-		return autopaho.ClientConfig{}, fmt.Errorf("newAutoPahoClientConfig: unable to parse URL: %w", err)
+		return autopaho.ClientConfig{}, fmt.Errorf("newAutoPahoClientConfig: unable to parse MQTT server URL: %w", err)
 	}
 
 	cliCfg := autopaho.ClientConfig{
@@ -94,6 +95,28 @@ func (edm *dnstapMinimiser) newAutoPahoClientConfig(caCertPool *x509.CertPool, s
 	}
 
 	return cliCfg, nil
+}
+
+func parseMQTTServerURL(server string) (*url.URL, error) {
+	if !strings.Contains(server, "://") {
+		server = "tls://" + server
+	}
+
+	u, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+	if u.Hostname() == "" {
+		return nil, fmt.Errorf("missing host in %q", server)
+	}
+
+	switch strings.ToLower(u.Scheme) {
+	case "mqtt", "tcp", "ssl", "tls", "mqtts", "mqtt+ssl", "tcps", "ws", "wss":
+	default:
+		return nil, fmt.Errorf("unsupported scheme %q", u.Scheme)
+	}
+
+	return u, nil
 }
 
 // startMQTTPipeline launches N JWS sign workers and 1 paho publisher. The

--- a/pkg/runner/mqtt_test.go
+++ b/pkg/runner/mqtt_test.go
@@ -443,3 +443,80 @@ func waitOrFail(t *testing.T, wg *sync.WaitGroup, d time.Duration, msg string) {
 		t.Fatal(msg)
 	}
 }
+
+func TestParseMQTTServerURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         string
+		wantScheme string
+		wantHost   string
+		wantErr    bool
+	}{
+		{
+			name:       "bare host port defaults to tls",
+			in:         "127.0.0.1:8883",
+			wantScheme: "tls",
+			wantHost:   "127.0.0.1:8883",
+		},
+		{
+			name:       "bare IPv6 host port defaults to tls",
+			in:         "[2001:db8::1]:8883",
+			wantScheme: "tls",
+			wantHost:   "[2001:db8::1]:8883",
+		},
+		{
+			name:       "explicit tls is preserved",
+			in:         "tls://mqtt.example:8883",
+			wantScheme: "tls",
+			wantHost:   "mqtt.example:8883",
+		},
+		{
+			name:       "explicit mqtt is preserved",
+			in:         "mqtt://mqtt.example:1883",
+			wantScheme: "mqtt",
+			wantHost:   "mqtt.example:1883",
+		},
+		{
+			name:       "explicit tcp is preserved",
+			in:         "tcp://mqtt.example:1883",
+			wantScheme: "tcp",
+			wantHost:   "mqtt.example:1883",
+		},
+		{
+			name:    "unsupported scheme",
+			in:      "ftp://mqtt.example:21",
+			wantErr: true,
+		},
+		{
+			name:    "missing host",
+			in:      "tls://",
+			wantErr: true,
+		},
+		{
+			name:    "missing hostname with port",
+			in:      "tls://:8883",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseMQTTServerURL(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseMQTTServerURL(%q) returned nil error", tc.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseMQTTServerURL(%q): %s", tc.in, err)
+			}
+			if got.Scheme != tc.wantScheme {
+				t.Fatalf("scheme have: %s, want: %s", got.Scheme, tc.wantScheme)
+			}
+			if got.Host != tc.wantHost {
+				t.Fatalf("host have: %s, want: %s", got.Host, tc.wantHost)
+			}
+		})
+	}
+}

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -1839,6 +1839,7 @@ func TestSetupMQTT(t *testing.T) {
 		edm := newTestDnstapMinimiser(t, defaultTC)
 		edm.conf.DataDir = t.TempDir()
 		edm.conf.MQTTSigningKeyFile = testJWKFile(t)
+		edm.conf.MQTTServer = "mqtts://example.test:8883"
 		edm.conf.DisableMQTTFilequeue = true
 		err := edm.setupMQTT()
 		if !errors.Is(err, errConnect) {


### PR DESCRIPTION
## Summary
- accept bare MQTT host:port values by defaulting them to tls://
- reject unsupported schemes and missing hostnames, including tls://:8883
- add focused URL parsing tests

## Tests
- go test ./pkg/runner ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MQTT server configuration now validates URLs more strictly, rejecting unsupported schemes and malformed inputs.
  * Server addresses without an explicit scheme are now automatically treated as TLS connections.
  * Hostname validation now requires non-empty values.

* **Tests**
  * Added comprehensive unit tests for MQTT server URL parsing and validation.
  * Updated existing test to use valid MQTT server URL format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->