### PR TITLE
fix(runner): retain sent histograms for 24 hours

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -379,14 +379,18 @@ func (edm *dnstapMinimiser) reverseLabelsBounded(labels []string, maxLen int) []
 	return boundedReverseLabels
 }
 
+const sentHistogramRetention = 24 * time.Hour
+
+func sentHistogramExpired(modTime, now time.Time) bool {
+	return now.Sub(modTime) > sentHistogramRetention
+}
+
 func (edm *dnstapMinimiser) diskCleaner(wg *sync.WaitGroup, sentDir string) {
 	// We will scan the directory each tick for sent files to remove.
 	defer wg.Done()
 
 	ticker := time.NewTicker(diskCleanerInterval)
 	defer ticker.Stop()
-
-	oneDay := time.Hour * 12
 
 timerLoop:
 	for {
@@ -412,7 +416,7 @@ timerLoop:
 						continue
 					}
 
-					if time.Since(fileInfo.ModTime()) > oneDay {
+					if sentHistogramExpired(fileInfo.ModTime(), time.Now()) {
 						absPath := filepath.Join(sentDir, dirEntry.Name())
 						edm.log.Info("diskCleaner: removing file", "filename", absPath)
 						err = osRemove(absPath)

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -2222,7 +2222,7 @@ func TestMonitorAndDiskCleaner(t *testing.T) {
 		if err := os.WriteFile(oldFile, []byte("x"), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		oldTime := time.Now().Add(-13 * time.Hour)
+		oldTime := time.Now().Add(-25 * time.Hour)
 		if err := os.Chtimes(oldFile, oldTime, oldTime); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -2132,3 +2132,15 @@ func TestWriteHistogramParquetExplicitThreshold(t *testing.T) {
 		}
 	}
 }
+
+func TestDiskCleanerRetentionThreshold(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+
+	if !sentHistogramExpired(now.Add(-25*time.Hour), now) {
+		t.Fatal("histogram older than 24 hours should expire")
+	}
+
+	if sentHistogramExpired(now.Add(-23*time.Hour), now) {
+		t.Fatal("histogram newer than 24 hours should not expire")
+	}
+}


### PR DESCRIPTION
## Summary
- correct sent histogram cleanup retention from 12 hours to 24 hours
- centralize the expiry check in a named helper used by diskCleaner
- test both sides of the 24-hour threshold

## Tests
- go test ./pkg/runner ./...