### PR TITLE
fix(runner): improve timestamp filename errors

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -2508,21 +2508,30 @@ timerLoop:
 	edm.log.Info("histogramSender: exiting loop")
 }
 
-func timestampsFromFilename(name string) (time.Time, time.Time, error) {
+func timestampsFromFilename(name string) (startTime time.Time, stopTime time.Time, err error) {
 	// expected name format: dns_histogram-2023-11-29T13-50-00Z_2023-11-29T13-51-00Z.parquet
 	trimmedName := strings.TrimSuffix(name, ".parquet")
 	nameParts := strings.SplitN(trimmedName, "-", 2)
+	if len(nameParts) != 2 {
+		err = fmt.Errorf("timestampFromFilename: missing '-' separating prefix from timestamps in %q", name)
+		return
+	}
 	times := strings.Split(nameParts[1], "_")
-	startTime, err := time.Parse("2006-01-02T15-04-05Z07:00", times[0])
-	if err != nil {
-		return time.Time{}, time.Time{}, fmt.Errorf("timestampFromFilename: unable to parse startTime: %w", err)
+	if len(times) != 2 {
+		err = fmt.Errorf("timestampFromFilename: missing '_' separating start and stop timestamps in %q", name)
+		return
 	}
-	stopTime, err := time.Parse("2006-01-02T15-04-05Z07:00", times[1])
+	startTime, err = time.Parse("2006-01-02T15-04-05Z07:00", times[0])
 	if err != nil {
-		return time.Time{}, time.Time{}, fmt.Errorf("timestampFromFilename: unable to parse stopTime: %w", err)
+		err = fmt.Errorf("timestampFromFilename: unable to parse startTime: %w", err)
+		return
 	}
-
-	return startTime, stopTime, nil
+	stopTime, err = time.Parse("2006-01-02T15-04-05Z07:00", times[1])
+	if err != nil {
+		err = fmt.Errorf("timestampFromFilename: unable to parse stopTime: %w", err)
+		return
+	}
+	return
 }
 
 func (edm *dnstapMinimiser) newQnamePublisher(wg *sync.WaitGroup) {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -296,6 +296,23 @@ func TestWKD(t *testing.T) {
 	}
 }
 
+func TestTimestampsFromFilenameRejectsMalformedNames(t *testing.T) {
+	tests := []string{
+		"dns_histogram.parquet",
+		"dns_histogram-2026-04-30T12-00-00Z.parquet",
+		"dns_histogram-bad_2026-04-30T12-01-00Z.parquet",
+		"dns_histogram-2026-04-30T12-00-00Z_bad.parquet",
+	}
+
+	for _, name := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := timestampsFromFilename(name); err == nil {
+				t.Fatal("timestampsFromFilename returned nil error")
+			}
+		})
+	}
+}
+
 func TestIgnoredClientIPsValid(t *testing.T) {
 	edm := newTestDnstapMinimiser(t, defaultTC)
 


### PR DESCRIPTION
## Summary
- validate histogram filename shape before indexing timestamp parts
- return explicit parse errors for malformed start/stop timestamps
- add malformed filename regression coverage

## Tests
- go test ./pkg/runner ./...