### PR TITLE
fix(aggregateSender): use cancellable dialer

### DIFF
--- a/pkg/runner/aggregate_sender.go
+++ b/pkg/runner/aggregate_sender.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"bufio"
+	"context"
 	"crypto/ed25519"
 	"crypto/tls"
 	"crypto/x509"
@@ -39,10 +40,10 @@ func (edm *dnstapMinimiser) newAggregateSender(aggrecURL *url.URL, signingJwk jw
 	// Create HTTP handler for sending aggregate files to aggrec
 	httpClient := http.Client{
 		Transport: &http.Transport{
-			Dial: (&net.Dialer{
+			DialContext: (&net.Dialer{
 				Timeout:   30 * time.Second,
 				KeepAlive: 30 * time.Second,
-			}).Dial,
+			}).DialContext,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ResponseHeaderTimeout: 10 * time.Second,
 			TLSClientConfig: &tls.Config{
@@ -74,7 +75,7 @@ func (edm *dnstapMinimiser) newAggregateSender(aggrecURL *url.URL, signingJwk jw
 }
 
 // Send histogram data via signed HTTP message to aggregate-receiver (https://github.com/dnstapir/aggregate-receiver)
-func (as aggregateSender) send(fileName string, ts time.Time, duration time.Duration) error {
+func (as aggregateSender) send(ctx context.Context, fileName string, ts time.Time, duration time.Duration) error {
 	fileName = filepath.Clean(fileName)
 	file, err := os.Open(fileName)
 	if err != nil {
@@ -99,7 +100,7 @@ func (as aggregateSender) send(fileName string, ts time.Time, duration time.Dura
 	}
 
 	// Send signed HTTP POST message
-	req, err := http.NewRequest("POST", histogramURL, bufio.NewReader(file))
+	req, err := http.NewRequestWithContext(ctx, "POST", histogramURL, bufio.NewReader(file))
 	if err != nil {
 		return fmt.Errorf("sendAggregateFile: unable to create request: %w", err)
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -2476,7 +2476,7 @@ timerLoop:
 					edm.aggregSenderMutex.RLock()
 					as := edm.aggregSender
 					edm.aggregSenderMutex.RUnlock()
-					err = as.send(absPath, startTS, duration)
+					err = as.send(edm.ctx, absPath, startTS, duration)
 					if err != nil {
 						edm.log.Error("histogramSender: unable to send histogram file", "error", err, "backoff_duration", backoffDuration)
 						sleep(backoffDuration)

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -1269,14 +1269,14 @@ func TestAggregateSender(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := as.send(fileName, time.Date(2026, 5, 28, 12, 34, 56, 0, time.UTC), 2*time.Minute); err != nil {
+	if err := as.send(t.Context(), fileName, time.Date(2026, 5, 28, 12, 34, 56, 0, time.UTC), 2*time.Minute); err != nil {
 		t.Fatal(err)
 	}
 	if !sawRequest {
 		t.Fatal("server did not receive request")
 	}
 
-	if err := as.send(filepath.Join(t.TempDir(), "missing.parquet"), time.Now(), time.Minute); err == nil {
+	if err := as.send(t.Context(), filepath.Join(t.TempDir(), "missing.parquet"), time.Now(), time.Minute); err == nil {
 		t.Fatal("sending missing file succeeded")
 	}
 
@@ -1309,7 +1309,7 @@ func TestAggregateSenderStatusAndLocationErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := as.send(fileName, time.Now(), time.Minute); err == nil {
+	if err := as.send(t.Context(), fileName, time.Now(), time.Minute); err == nil {
 		t.Fatal("unexpected status succeeded")
 	}
 
@@ -1323,7 +1323,7 @@ func TestAggregateSenderStatusAndLocationErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 	as.aggrecURL = locationURL
-	if err := as.send(fileName, time.Now(), time.Minute); err == nil {
+	if err := as.send(t.Context(), fileName, time.Now(), time.Minute); err == nil {
 		t.Fatal("bad Location succeeded")
 	}
 }


### PR DESCRIPTION
## Summary
- switch aggregate sender transport from Dial to DialContext
- preserve existing timeout and keepalive settings while allowing request cancellation to propagate

## Tests
- go test ./pkg/runner ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * HTTP sending now respects request contexts so connection setup and POST requests are cancellable and tied to operation lifecycle.
* **Behavior**
  * Send operations are now bound to shutdown/cancellation contexts to avoid hanging or orphaned requests during shutdown.
* **Tests**
  * Tests updated to exercise the context-aware send behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->