### PR TITLE
fix(runner): release fs watcher lock on removal errors

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1094,6 +1094,7 @@ func (edm *dnstapMinimiser) addFSWatchers(fileToFuncs map[string][]func() error)
 
 func (edm *dnstapMinimiser) cleanupFSWatchers() error {
 	edm.fsWatcherMutex.RLock()
+	defer edm.fsWatcherMutex.RUnlock()
 	for _, watchPath := range edm.fsWatcher.WatchList() {
 		watchPathInUse := false
 		for fsWatcherFuncFilename := range edm.fsWatcherFuncs {
@@ -1104,13 +1105,12 @@ func (edm *dnstapMinimiser) cleanupFSWatchers() error {
 
 		if !watchPathInUse {
 			edm.log.Info("cleanupFSWatchers: cleaning up path watcher", "watch_path", watchPath)
-			err := edm.fsWatcher.Remove(watchPath)
+			err := removeFSWatcherPath(edm.fsWatcher, watchPath)
 			if err != nil {
 				return fmt.Errorf("cleanupFSWatchers: unable to remove path watcher '%s': %w", watchPath, err)
 			}
 		}
 	}
-	edm.fsWatcherMutex.RUnlock()
 
 	return nil
 }

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -2132,3 +2132,34 @@ func TestWriteHistogramParquetExplicitThreshold(t *testing.T) {
 		}
 	}
 }
+
+func TestCleanupFSWatchersReleasesLockOnError(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+
+	// Watch a directory that is not referenced by any callback so
+	// cleanupFSWatchers tries to remove it.
+	if err := edm.fsWatcher.Add(t.TempDir()); err != nil {
+		t.Fatalf("Add watch path: %s", err)
+	}
+	edm.fsWatcherFuncs = make(map[string][]func() error)
+
+	removeErr := errors.New("remove failed")
+	oldRemoveFSWatcherPath := removeFSWatcherPath
+	removeFSWatcherPath = func(_ *fsnotify.Watcher, _ string) error {
+		return removeErr
+	}
+	t.Cleanup(func() {
+		removeFSWatcherPath = oldRemoveFSWatcherPath
+	})
+
+	err := edm.cleanupFSWatchers()
+	if !errors.Is(err, removeErr) {
+		t.Fatalf("cleanupFSWatchers error have: %v, want: %v", err, removeErr)
+	}
+
+	// The RLock must have been released even though removal failed.
+	if !edm.fsWatcherMutex.TryLock() {
+		t.Fatal("fsWatcherMutex.TryLock() failed - mutex is still locked after cleanupFSWatchers")
+	}
+	edm.fsWatcherMutex.Unlock()
+}

--- a/pkg/runner/seams.go
+++ b/pkg/runner/seams.go
@@ -42,6 +42,12 @@ var (
 	osReadDir  = os.ReadDir
 	osStat     = os.Stat
 
+	// removeFSWatcherPath wraps (*fsnotify.Watcher).Remove so tests can
+	// inject removal failures into cleanupFSWatchers.
+	removeFSWatcherPath = func(w *fsnotify.Watcher, path string) error {
+		return w.Remove(path)
+	}
+
 	now                     = time.Now
 	sleep                   = time.Sleep
 	configUpdateDebounce    = 100 * time.Millisecond


### PR DESCRIPTION
## Summary
- release cleanupFSWatchers RLock with defer on all exit paths
- add a small removal hook so the error path can be exercised directly
- assert the mutex is released after a watcher removal failure

## Tests
- go test ./pkg/runner ./...