### PR TITLE
fix(runner): tolerate partial dnstap metadata

### DIFF
--- a/pkg/runner/partial_dnstap_test.go
+++ b/pkg/runner/partial_dnstap_test.go
@@ -1,0 +1,104 @@
+package runner
+
+import (
+	"net/netip"
+	"testing"
+	"time"
+
+	dnstap "github.com/dnstap/golang-dnstap"
+	"github.com/miekg/dns"
+)
+
+func TestParsePacketMissingTimestamps(t *testing.T) {
+	edm := discardEDM()
+	wire := packedDNSMsg(t, "example.com.", dns.TypeA, dns.RcodeSuccess)
+	epoch := time.Unix(0, 0).UTC()
+
+	tests := []struct {
+		name    string
+		isQuery bool
+		dt      *dnstap.Dnstap
+	}{
+		{
+			name:    "query timestamp missing",
+			isQuery: true,
+			dt: &dnstap.Dnstap{
+				Message: &dnstap.Message{QueryMessage: wire},
+			},
+		},
+		{
+			name:    "response timestamp missing",
+			isQuery: false,
+			dt: &dnstap.Dnstap{
+				Message: &dnstap.Message{ResponseMessage: wire},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg, got := edm.parsePacket(tc.dt, tc.isQuery)
+			if msg == nil {
+				t.Fatal("parsePacket returned nil DNS message")
+			}
+			if !got.Equal(epoch) {
+				t.Fatalf("timestamp have: %s, want: %s", got, epoch)
+			}
+		})
+	}
+}
+
+func TestParsePacketMissingMessage(t *testing.T) {
+	edm := discardEDM()
+	msg, got := edm.parsePacket(&dnstap.Dnstap{}, false)
+	if msg != nil {
+		t.Fatalf("parsePacket should return nil DNS message when dnstap message is missing, have: %#v", msg)
+	}
+	if want := time.Unix(0, 0).UTC(); !got.Equal(want) {
+		t.Fatalf("timestamp have: %s, want: %s", got, want)
+	}
+}
+
+func TestNewSessionAllowsMissingSocketMetadata(t *testing.T) {
+	edm := discardEDM()
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeA)
+
+	sd := edm.newSession(&dnstap.Dnstap{
+		Message: &dnstap.Message{},
+	}, msg, false, defaultLabelLimit, time.Unix(0, 0).UTC())
+
+	if sd.DNSProtocol != nil {
+		t.Fatalf("DNSProtocol should be nil when SocketProtocol is missing, have: %d", *sd.DNSProtocol)
+	}
+	if sd.SourceIPv4 != nil || sd.DestIPv4 != nil ||
+		sd.SourceIPv6Network != nil || sd.SourceIPv6Host != nil ||
+		sd.DestIPv6Network != nil || sd.DestIPv6Host != nil {
+		t.Fatalf("IP fields should stay nil when SocketFamily is missing: %#v", sd)
+	}
+}
+
+func TestFormatDnstapEndpoint(t *testing.T) {
+	addr := netip.MustParseAddr("198.51.100.20").AsSlice()
+	port := uint32(12345)
+
+	tests := []struct {
+		name    string
+		ipBytes []byte
+		port    *uint32
+		want    string
+	}{
+		{name: "address and port", ipBytes: addr, port: &port, want: "198.51.100.20:12345"},
+		{name: "address without port", ipBytes: addr, port: nil, want: "198.51.100.20:?"},
+		{name: "port without address", ipBytes: nil, port: &port, want: "?:12345"},
+		{name: "neither address nor port", ipBytes: nil, port: nil, want: "?"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatDnstapEndpoint(tc.ipBytes, tc.port); got != tc.want {
+				t.Fatalf("endpoint have: %s, want: %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -14,7 +14,6 @@ import (
 	"log"
 	"log/slog"
 	"math"
-	"net"
 	"net/http"
 	_ "net/http/pprof" // #nosec G108 -- pprofServer only listens to localhost
 	"net/netip"
@@ -1991,7 +1990,16 @@ minimiserLoop:
 				}
 			}
 
-			isQuery := strings.HasSuffix(dnstap.Message_Type_name[int32(*dt.Message.Type)], "_QUERY")
+			// Guard the hot-path dereferences (here and below: QueryAddress,
+			// clientIPIsIgnored) so a partially populated frame is dropped
+			// rather than panicking before parsePacket's own nil checks.
+			if dt.Message == nil || dt.Message.Type == nil {
+				edm.log.Error("runMinimiser: dnstap message or type missing, dropping packet", "minimiser_id", minimiserID)
+				edm.promDNSParseError.Inc()
+				continue
+			}
+
+			isQuery := strings.HasSuffix(dnstap.Message_Type_name[int32(dt.Message.GetType())], "_QUERY")
 
 			// For now we only care about response type dnstap packets
 			if isQuery {
@@ -2148,7 +2156,7 @@ func (edm *dnstapMinimiser) newSession(dt *dnstap.Dnstap, msg *dns.Msg, isQuery 
 		sd.ServerID = &sID
 	}
 
-	switch *dt.Message.SocketFamily {
+	switch dt.Message.GetSocketFamily() {
 	case dnstap.SocketFamily_INET:
 		if dt.Message.QueryAddress != nil {
 			sourceIPInt, err := ipBytesToInt(dt.Message.QueryAddress)
@@ -2193,11 +2201,17 @@ func (edm *dnstapMinimiser) newSession(dt *dnstap.Dnstap, msg *dns.Msg, isQuery 
 				sd.DestIPv6Host = &i64dIntHost
 			}
 		}
+	case 0:
+		// SocketFamily not set: tolerate partial metadata and leave the IP
+		// fields nil rather than logging an error for every such packet.
 	default:
 		edm.log.Error("packet is neither INET or INET6")
 	}
 
-	sd.DNSProtocol = (*int32)(dt.Message.SocketProtocol)
+	if dt.Message.SocketProtocol != nil {
+		dnsProtocol := int32(dt.Message.GetSocketProtocol())
+		sd.DNSProtocol = &dnsProtocol
+	}
 
 	return sd
 }
@@ -2550,34 +2564,16 @@ func (edm *dnstapMinimiser) newQnamePublisher(wg *sync.WaitGroup) {
 }
 
 func (edm *dnstapMinimiser) parsePacket(dt *dnstap.Dnstap, isQuery bool) (*dns.Msg, time.Time) {
-	var t time.Time
 	var err error
-	var queryAddress, responseAddress string
 
-	qa := net.IP(dt.Message.QueryAddress)
-	ra := net.IP(dt.Message.ResponseAddress)
-
-	// Query address: 10.10.10.10:31337, 10.10.10.10:?, ?:31337 or ?
-	if qa != nil && dt.Message.QueryPort != nil {
-		queryAddress = qa.String() + ":" + strconv.FormatUint(uint64(*dt.Message.QueryPort), 10)
-	} else if qa != nil {
-		queryAddress = qa.String() + ":?"
-	} else if dt.Message.ResponsePort != nil {
-		queryAddress = "?:" + strconv.FormatUint(uint64(*dt.Message.QueryPort), 10)
-	} else {
-		queryAddress = "?"
+	if dt.Message == nil {
+		edm.log.Error("parsePacket: dnstap message is missing")
+		return nil, time.Unix(0, 0).UTC()
 	}
 
-	// Response address: 10.10.10.10:31337, 10.10.10.10:?, ?:31337 or ?
-	if ra != nil && dt.Message.ResponsePort != nil {
-		responseAddress = ra.String() + ":" + strconv.FormatUint(uint64(*dt.Message.ResponsePort), 10)
-	} else if ra != nil {
-		responseAddress = ra.String() + ":?"
-	} else if dt.Message.ResponsePort != nil {
-		responseAddress = "?:" + strconv.FormatUint(uint64(*dt.Message.ResponsePort), 10)
-	} else {
-		responseAddress = "?"
-	}
+	queryAddress := formatDnstapEndpoint(dt.Message.QueryAddress, dt.Message.QueryPort)
+	responseAddress := formatDnstapEndpoint(dt.Message.ResponseAddress, dt.Message.ResponsePort)
+
 	msg := new(dns.Msg)
 	if isQuery {
 		err = msg.Unpack(dt.Message.QueryMessage)
@@ -2585,27 +2581,49 @@ func (edm *dnstapMinimiser) parsePacket(dt *dnstap.Dnstap, isQuery bool) (*dns.M
 			edm.log.Error("unable to unpack query message", "error", err, "query_address", queryAddress, "response_address", responseAddress)
 			msg = nil
 		}
-		if *dt.Message.QueryTimeSec > math.MaxInt64 {
-			edm.log.Error("dt.Message.QueryTimeSec is too large for int64, setting time to 0", "value", *dt.Message.QueryTimeSec)
-			*dt.Message.QueryTimeSec = 0
-			*dt.Message.QueryTimeNsec = 0
-		}
-		t = time.Unix(int64(*dt.Message.QueryTimeSec), int64(*dt.Message.QueryTimeNsec)).UTC() // #nosec G115 -- Will be zeroed out above if too large, https://github.com/securego/gosec/issues/1212#issuecomment-2739574884
-	} else {
-		err = msg.Unpack(dt.Message.ResponseMessage)
-		if err != nil {
-			edm.log.Error("unable to unpack response message", "error", err, "query_address", queryAddress, "response_address", responseAddress)
-			msg = nil
-		}
-		if *dt.Message.ResponseTimeSec > math.MaxInt64 {
-			edm.log.Error("dt.Message.ResponseTimeSec is too large for int64, setting time to 0", "value", *dt.Message.ResponseTimeSec)
-			*dt.Message.ResponseTimeSec = 0
-			*dt.Message.ResponseTimeNsec = 0
-		}
-		t = time.Unix(int64(*dt.Message.ResponseTimeSec), int64(*dt.Message.ResponseTimeNsec)).UTC() // #nosec G115 -- Will be zeroed out above if too large, https://github.com/securego/gosec/issues/1212#issuecomment-2739574884
+		t := edm.dnstapTimestamp(dt.Message.QueryTimeSec, dt.Message.QueryTimeNsec, "dt.Message.QueryTimeSec")
+		return msg, t
 	}
 
+	err = msg.Unpack(dt.Message.ResponseMessage)
+	if err != nil {
+		edm.log.Error("unable to unpack response message", "error", err, "query_address", queryAddress, "response_address", responseAddress)
+		msg = nil
+	}
+	t := edm.dnstapTimestamp(dt.Message.ResponseTimeSec, dt.Message.ResponseTimeNsec, "dt.Message.ResponseTimeSec")
 	return msg, t
+}
+
+func formatDnstapEndpoint(ipBytes []byte, port *uint32) string {
+	ip, ok := netip.AddrFromSlice(ipBytes)
+	if ok && port != nil {
+		return ip.String() + ":" + strconv.FormatUint(uint64(*port), 10)
+	}
+	if ok {
+		return ip.String() + ":?"
+	}
+	if port != nil {
+		return "?:" + strconv.FormatUint(uint64(*port), 10)
+	}
+	return "?"
+}
+
+func (edm *dnstapMinimiser) dnstapTimestamp(sec *uint64, nsec *uint32, fieldName string) time.Time {
+	if sec == nil {
+		edm.log.Error(fieldName + " is missing, setting time to 0")
+		return time.Unix(0, 0).UTC()
+	}
+	if *sec > math.MaxInt64 {
+		edm.log.Error(fieldName+" is too large for int64, setting time to 0", "value", *sec)
+		return time.Unix(0, 0).UTC()
+	}
+
+	var nsecValue uint32
+	if nsec != nil {
+		nsecValue = *nsec
+	}
+
+	return time.Unix(int64(*sec), int64(nsecValue)).UTC() // #nosec G115 -- sec is checked above and nsec is uint32.
 }
 
 func ipBytesToInt(ip4Bytes []byte) (uint32, error) {

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -717,10 +717,8 @@ func TestSessionParquetAndSessionConstruction(t *testing.T) {
 // arms of parsePacket that the addr+port-present canary in
 // TestSessionParquetAndSessionConstruction does not reach: the
 // addr-without-port and all-nil fallbacks, plus the response-unpack-error
-// path. The qa==nil && QueryPort==nil && ResponsePort!=nil branch is
-// intentionally not exercised — it dereferences *QueryPort despite the
-// guard and is unreachable without panicking, so it is left
-// accepted-as-uncovered.
+// path. The port-without-address branch is covered directly by
+// TestFormatDnstapEndpoint.
 func TestParsePacketAddressFormattingBranches(t *testing.T) {
 	edm := newTestDnstapMinimiser(t, defaultTC)
 	packed := packedDNSMsg(t, "www.example.com.", dns.TypeA, dns.RcodeSuccess)


### PR DESCRIPTION
## Summary
- tolerate dnstap messages with missing timestamps and socket metadata
- avoid formatting empty addresses as invalid endpoints
- assert all IP-derived session fields remain nil when metadata is absent

## Tests
- go test ./pkg/runner ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust DNSTAP handling: avoids panics, drops malformed/partially-populated frames with diagnostics, and consistently yields zero/UTC timestamps when metadata is missing while tolerating absent socket/protocol information.

* **Tests**
  * Added unit tests covering missing timestamps/messages, incomplete socket metadata, and endpoint-formatting variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->