### PR TITLE
fix(runner): reject mismatched IPv4 session addresses

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -2613,6 +2613,10 @@ func ipBytesToInt(ip4Bytes []byte) (uint32, error) {
 	if !ok {
 		return 0, fmt.Errorf("ipBytesToInt: unable to parse bytes")
 	}
+	ip = ip.Unmap()
+	if !ip.Is4() {
+		return 0, fmt.Errorf("ipBytesToInt: address is not IPv4: %s", ip)
+	}
 
 	// Make sure we are dealing with 4 byte IPv4 address data (and deal with IPv4-in-IPv6 addresses)
 	ip4 := ip.As4()

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -763,7 +763,8 @@ func TestParsePacketAddressFormattingBranches(t *testing.T) {
 // TestNewSessionBranches covers newSession arms that
 // TestSessionParquetAndSessionConstruction (basic INET/INET6 happy paths)
 // does not reach: port overflow, ipBytesToInt error from bad address
-// bytes, ip6BytesToInt error from bad address bytes, and the unknown
+// bytes, ipBytesToInt error from IPv6 bytes carried on an INET family,
+// ip6BytesToInt error from bad address bytes, and the unknown
 // SocketFamily default arm.
 func TestNewSessionBranches(t *testing.T) {
 	edm := newTestDnstapMinimiser(t, defaultTC)
@@ -795,6 +796,20 @@ func TestNewSessionBranches(t *testing.T) {
 		}
 		if sd.DestIPv4 != nil {
 			t.Fatalf("DestIPv4 should be nil for bad addr bytes, got %v", *sd.DestIPv4)
+		}
+	})
+
+	t.Run("mismatched IPv6 address bytes with INET family leaves IPv4 nil", func(t *testing.T) {
+		dt := testDnstapMessage(t, dnstap.Message_CLIENT_RESPONSE, dnstap.SocketFamily_INET, packed)
+		dt.Message.QueryAddress = netip.MustParseAddr("2001:db8::20").AsSlice()
+		dt.Message.ResponseAddress = netip.MustParseAddr("2001:db8::53").AsSlice()
+		msg, ts := edm.parsePacket(dt, false)
+		sd := edm.newSession(dt, msg, false, defaultLabelLimit, ts)
+		if sd.SourceIPv4 != nil {
+			t.Fatalf("SourceIPv4 should be nil for IPv6 bytes with INET family, got %d", *sd.SourceIPv4)
+		}
+		if sd.DestIPv4 != nil {
+			t.Fatalf("DestIPv4 should be nil for IPv6 bytes with INET family, got %d", *sd.DestIPv4)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- reject IPv6 address bytes when dnstap marks the socket family as IPv4
- leave IPv4 session fields nil instead of converting mismatched bytes
- add a focused newSession regression test

## Tests
- go test ./pkg/runner ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened IP address validation to properly normalize and validate IPv4 addresses, with improved error handling for address family inconsistencies.

* **Tests**
  * Expanded test suite to cover additional address handling scenarios, ensuring proper validation and initialization across different address families.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->