### PR TITLE
fix(runner): deduplicate concurrent new qnames

### DIFF
--- a/pkg/runner/run_minimiser_test.go
+++ b/pkg/runner/run_minimiser_test.go
@@ -1,0 +1,51 @@
+package runner
+
+import (
+	"sync"
+	"testing"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/miekg/dns"
+)
+
+func TestQnameSeenConcurrentFirstSeenOnce(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+
+	seenQnameLRU, err := lru.New[string, struct{}](10)
+	if err != nil {
+		t.Fatalf("lru.New: %s", err)
+	}
+
+	pdb := newTestPebble(t)
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("race.example.", dns.TypeA)
+
+	const goroutines = 64
+	start := make(chan struct{})
+	results := make(chan bool, goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			results <- edm.qnameSeen(msg, seenQnameLRU, pdb)
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+
+	var firstSeen int
+	for seen := range results {
+		if !seen {
+			firstSeen++
+		}
+	}
+	if firstSeen != 1 {
+		t.Fatalf("first-seen results have: %d, want: 1", firstSeen)
+	}
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1504,6 +1504,7 @@ type dnstapMinimiser struct {
 	reloadMinimiserMutex          sync.RWMutex
 	reloadMinimiserConfigCh       []chan struct{}
 	reloadHistogramSenderConfigCh chan struct{}
+	seenQnameLocks                [seenQnameLockShards]sync.Mutex
 }
 
 func createCryptopan(key string, salt string) (*cryptopan.Cryptopan, error) {
@@ -1857,18 +1858,32 @@ func (wkd *wellKnownDomainsTracker) rotateTracker(edm *dnstapMinimiser, dawgFile
 	return prevWKD, nil
 }
 
+// seenQnameLockShards is the number of mutexes sharding qnameSeen by qname.
+//
+// It bounds [dnstapMinimiser.seenQnameLocks] and the modulus in
+// [seenQnameLockIndex], so both stay in sync.
+const seenQnameLockShards = 256
+
+// seenQnameLockIndex maps qname to a shard in [dnstapMinimiser.seenQnameLocks].
+//
+// It hashes qname with FNV-1a and reduces the result modulo
+// [seenQnameLockShards], so the returned index is always a valid offset into
+// the lock array.
+func seenQnameLockIndex(qname string) int {
+	var h uint32 = 2166136261
+	for i := 0; i < len(qname); i++ {
+		h ^= uint32(qname[i])
+		h *= 16777619
+	}
+	return int(h % seenQnameLockShards)
+}
+
 // Check if we have already seen this qname since we started.
 func (edm *dnstapMinimiser) qnameSeen(msg *dns.Msg, seenQnameLRU *lru.Cache[string, struct{}], pdb *pebble.DB) bool {
-	// NOTE: This looks like it might be a race (calling
-	// Get() followed by separate Add()) but since we want
-	// to keep often looked-up names in the cache we need to
-	// use Get() for updating recent-ness, and there is no
-	// GetOrAdd() method available. However, it should be
-	// safe for multiple threads to call Add() as this will
-	// only move an already added entry to the front of the
-	// eviction list which should be OK.
-
 	qname := strings.ToLower(msg.Question[0].Name)
+	seenLock := &edm.seenQnameLocks[seenQnameLockIndex(qname)]
+	seenLock.Lock()
+	defer seenLock.Unlock()
 
 	_, ok := seenQnameLRU.Get(qname)
 	if ok {


### PR DESCRIPTION
## Summary
- serialize first-seen checks per qname with sharded locks
- prevent concurrent workers from publishing duplicate new-qname events for the same name
- add a concurrent qnameSeen regression test

## Tests
- go test ./pkg/runner ./...