### PR TITLE
fix(runner): flush collector data on shutdown

### DIFF
--- a/pkg/runner/data_collector_test.go
+++ b/pkg/runner/data_collector_test.go
@@ -1,0 +1,156 @@
+package runner
+
+import (
+	"io"
+	"log/slog"
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/smhanov/dawg"
+	"github.com/spaolacci/murmur3"
+)
+
+func TestDataCollectorFlushesPendingDataOnShutdown(t *testing.T) {
+	edm, wkdTracker := newDataCollectorTestFixture(t, "example.com.")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go edm.dataCollector(&wg, wkdTracker, "unused-in-shutdown-test.dawg")
+
+	serverID := "serverID"
+	edm.sessionCollectorCh <- &sessionData{ServerID: &serverID}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeA)
+	ip := netip.MustParseAddr("198.51.100.10")
+	dawgIndex, suffixMatch, dawgModTime := wkdTracker.lookup(msg)
+	wkdTracker.updateCh <- wkdUpdate{
+		dawgIndex:   dawgIndex,
+		suffixMatch: suffixMatch,
+		dawgModTime: dawgModTime,
+		histogramData: histogramData{
+			ACount:  1,
+			OKCount: 1,
+		},
+		hllHash: murmur3.Sum64(ip.AsSlice()),
+		ip:      ip,
+	}
+
+	close(wkdTracker.stop)
+	waitOrFail(t, &wg, 2*time.Second, "dataCollector did not exit after stop")
+
+	ps, ok := <-edm.sessionWriterCh
+	if !ok {
+		t.Fatal("sessionWriterCh closed without flushing pending session data")
+	}
+	if len(ps.sessions) != 1 {
+		t.Fatalf("flushed sessions have: %d, want: 1", len(ps.sessions))
+	}
+	if ps.startTime.IsZero() {
+		t.Fatal("flushed sessions should carry the collector interval start")
+	}
+	if ps.rotationTime.Before(ps.startTime) {
+		t.Fatalf("session interval is inverted: start=%s stop=%s", ps.startTime, ps.rotationTime)
+	}
+
+	prevWKD, ok := <-edm.histogramWriterCh
+	if !ok {
+		t.Fatal("histogramWriterCh closed without flushing pending histogram data")
+	}
+	if len(prevWKD.m) != 1 {
+		t.Fatalf("flushed histogram domains have: %d, want: 1", len(prevWKD.m))
+	}
+	got := prevWKD.m[dawgIndex]
+	if got == nil {
+		t.Fatalf("flushed histogram missing DAWG index %d", dawgIndex)
+	}
+	if got.ACount != 1 || got.OKCount != 1 {
+		t.Fatalf("flushed histogram counts have A=%d OK=%d, want A=1 OK=1", got.ACount, got.OKCount)
+	}
+	if prevWKD.startTime.IsZero() {
+		t.Fatal("flushed histogram should carry the collector interval start")
+	}
+	if prevWKD.rotationTime.Before(prevWKD.startTime) {
+		t.Fatalf("histogram interval is inverted: start=%s stop=%s", prevWKD.startTime, prevWKD.rotationTime)
+	}
+}
+
+func TestDataCollectorAdvancesSessionIntervalWhenRotationFails(t *testing.T) {
+	edm, wkdTracker := newDataCollectorTestFixture(t, "example.com.")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	// A missing dawg file makes rotateTracker fail, exercising the path
+	// where session data is flushed but histogram rotation errors out.
+	go edm.dataCollector(&wg, wkdTracker, "missing-dawg-file.dawg")
+
+	firstServerID := "first"
+	edm.sessionCollectorCh <- &sessionData{ServerID: &firstServerID}
+
+	rotationTime := time.Now().UTC()
+	done := make(chan error, 1)
+	edm.parquetRotationRequestCh <- parquetRotationRequest{
+		rotationTime: rotationTime,
+		done:         done,
+	}
+	if err := <-done; err == nil {
+		t.Fatal("manual rotation with missing dawg file should fail")
+	}
+
+	// The failed rotation still flushed the first session interval.
+	first, ok := <-edm.sessionWriterCh
+	if !ok {
+		t.Fatal("sessionWriterCh closed without flushing the first session interval")
+	}
+	if len(first.sessions) != 1 {
+		t.Fatalf("first flushed sessions have: %d, want: 1", len(first.sessions))
+	}
+	if !first.rotationTime.Equal(rotationTime) {
+		t.Fatalf("first flushed sessions stop at %s, want %s", first.rotationTime, rotationTime)
+	}
+
+	secondServerID := "second"
+	edm.sessionCollectorCh <- &sessionData{ServerID: &secondServerID}
+
+	close(wkdTracker.stop)
+	waitOrFail(t, &wg, 2*time.Second, "dataCollector did not exit after stop")
+
+	// The shutdown flush must start the second session interval at the
+	// failed rotation's time, proving the session boundary advanced even
+	// though histogram rotation failed.
+	second, ok := <-edm.sessionWriterCh
+	if !ok {
+		t.Fatal("sessionWriterCh closed without flushing the second session interval")
+	}
+	if len(second.sessions) != 1 {
+		t.Fatalf("second flushed sessions have: %d, want: 1", len(second.sessions))
+	}
+	if !second.startTime.Equal(rotationTime) {
+		t.Fatalf("second session interval starts at %s, want %s", second.startTime, rotationTime)
+	}
+}
+
+func newDataCollectorTestFixture(t *testing.T, knownDomains ...string) (*dnstapMinimiser, *wellKnownDomainsTracker) {
+	t.Helper()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	edm, err := newDnstapMinimiser(logger, defaultTC)
+	if err != nil {
+		t.Fatalf("newDnstapMinimiser: %s", err)
+	}
+	t.Cleanup(edm.stop)
+
+	dBuilder := dawg.New()
+	for _, domain := range knownDomains {
+		dBuilder.Add(domain)
+	}
+	wkdTracker, err := newWellKnownDomainsTracker(dBuilder.Finish(), time.Unix(0, 0))
+	if err != nil {
+		t.Fatalf("newWellKnownDomainsTracker: %s", err)
+	}
+
+	return edm, wkdTracker
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -260,6 +260,7 @@ type sessionData struct {
 
 type prevSessions struct {
 	sessions     []*sessionData
+	startTime    time.Time
 	rotationTime time.Time
 }
 
@@ -1671,6 +1672,7 @@ type wellKnownDomainsData struct {
 	// Store a pointer to histogramData so we can assign to it without
 	// "cannot assign to struct field in map" issues
 	m             map[int]*histogramData
+	startTime     time.Time
 	rotationTime  time.Time
 	dawgFinder    dawg.Finder
 	dawgIsRotated bool
@@ -1820,7 +1822,7 @@ func (wkd *wellKnownDomainsTracker) sendUpdate(ipBytes []byte, msg *dns.Msg, daw
 	wkd.updateCh <- wu
 }
 
-func (wkd *wellKnownDomainsTracker) rotateTracker(edm *dnstapMinimiser, dawgFile string, rotationTime time.Time) (*wellKnownDomainsData, error) {
+func (wkd *wellKnownDomainsTracker) rotateTracker(edm *dnstapMinimiser, dawgFile string, startTime time.Time, rotationTime time.Time) (*wellKnownDomainsData, error) {
 	dawgFileChanged := false
 	var dawgFinder dawg.Finder
 
@@ -1844,6 +1846,8 @@ func (wkd *wellKnownDomainsTracker) rotateTracker(edm *dnstapMinimiser, dawgFile
 	wkd.mutex.Lock()
 	prevWKD.m = wkd.m
 	prevWKD.dawgFinder = wkd.dawgFinder
+	prevWKD.startTime = startTime
+	prevWKD.rotationTime = rotationTime
 	wkd.m = map[int]*histogramData{}
 	if dawgFileChanged {
 		wkd.dawgFinder = dawgFinder
@@ -1851,8 +1855,6 @@ func (wkd *wellKnownDomainsTracker) rotateTracker(edm *dnstapMinimiser, dawgFile
 		prevWKD.dawgIsRotated = true
 	}
 	wkd.mutex.Unlock()
-
-	prevWKD.rotationTime = rotationTime
 
 	return prevWKD, nil
 }
@@ -2206,7 +2208,7 @@ func (edm *dnstapMinimiser) createSessionFile(ps *prevSessions, dataDir string) 
 	// Write session file to a sessions dir where it can be read by other tools
 	sessionsDir := filepath.Join(dataDir, "parquet", "sessions")
 
-	startTime := getStartTimeFromRotationTime(ps.rotationTime)
+	startTime := intervalStartFromTimes(ps.startTime, ps.rotationTime)
 
 	absoluteTmpFileName, absoluteFileName := buildParquetFilenames(sessionsDir, "dns_session_block", startTime, ps.rotationTime)
 
@@ -2237,7 +2239,7 @@ func (edm *dnstapMinimiser) sessionWriter(dataDir string, wg *sync.WaitGroup) {
 }
 
 func (edm *dnstapMinimiser) createHistogramFile(prevWellKnownDomainsData *wellKnownDomainsData, labelLimit int, outboxDir string) (string, error) {
-	startTime := getStartTimeFromRotationTime(prevWellKnownDomainsData.rotationTime)
+	startTime := intervalStartFromTimes(prevWellKnownDomainsData.startTime, prevWellKnownDomainsData.rotationTime)
 
 	absoluteTmpFileName, absoluteFileName := buildParquetFilenames(outboxDir, "dns_histogram", startTime, prevWellKnownDomainsData.rotationTime)
 
@@ -2690,6 +2692,13 @@ func getStartTimeFromRotationTime(rotationTime time.Time) time.Time {
 	return rotationTime.Add(-time.Second * 60)
 }
 
+func intervalStartFromTimes(startTime time.Time, rotationTime time.Time) time.Time {
+	if !startTime.IsZero() {
+		return startTime
+	}
+	return getStartTimeFromRotationTime(rotationTime)
+}
+
 // Unfortunately the hll library does not expose what format
 // the HLL is being stored in so figure things out manually.
 //
@@ -2955,6 +2964,8 @@ func (edm *dnstapMinimiser) dataCollector(wg *sync.WaitGroup, wkd *wellKnownDoma
 	go wkd.updateRetryer(edm, &retryerWg)
 
 	sessions := []*sessionData{}
+	sessionIntervalStart := time.Now().UTC()
+	histogramIntervalStart := sessionIntervalStart
 
 	ticker := time.NewTicker(timeUntilNextMinute())
 	defer ticker.Stop()
@@ -2973,12 +2984,13 @@ func (edm *dnstapMinimiser) dataCollector(wg *sync.WaitGroup, wkd *wellKnownDoma
 		sessionUpdated = true
 	}
 
-	flushSessions := func(rotationTime time.Time) {
+	flushSessions := func(startTime time.Time, rotationTime time.Time) {
 		if !sessionUpdated {
 			return
 		}
 		ps := &prevSessions{
 			sessions:     sessions,
+			startTime:    startTime,
 			rotationTime: rotationTime,
 		}
 		sessions = []*sessionData{}
@@ -3039,10 +3051,10 @@ func (edm *dnstapMinimiser) dataCollector(wg *sync.WaitGroup, wkd *wellKnownDoma
 		}
 	}
 
-	rotateCollectedData := func(rotationTime time.Time) error {
-		flushSessions(rotationTime)
+	rotateCollectedData := func(sessionStart time.Time, histogramStart time.Time, rotationTime time.Time) error {
+		flushSessions(sessionStart, rotationTime)
 
-		prevWKD, err := wkd.rotateTracker(edm, dawgFile, rotationTime)
+		prevWKD, err := wkd.rotateTracker(edm, dawgFile, histogramStart, rotationTime)
 		if err != nil {
 			return fmt.Errorf("unable to rotate histogram map: %w", err)
 		}
@@ -3053,6 +3065,19 @@ func (edm *dnstapMinimiser) dataCollector(wg *sync.WaitGroup, wkd *wellKnownDoma
 		}
 
 		return nil
+	}
+
+	flushHistogram := func(startTime time.Time, rotationTime time.Time) {
+		if len(wkd.m) == 0 {
+			return
+		}
+		edm.histogramWriterCh <- &wellKnownDomainsData{
+			m:            wkd.m,
+			startTime:    startTime,
+			rotationTime: rotationTime,
+			dawgFinder:   wkd.dawgFinder,
+		}
+		wkd.m = map[int]*histogramData{}
 	}
 
 collectorLoop:
@@ -3068,10 +3093,14 @@ collectorLoop:
 			// We want to tick at the start of each minute
 			ticker.Reset(timeUntilNextMinute())
 
-			if err := rotateCollectedData(ts); err != nil {
+			err := rotateCollectedData(sessionIntervalStart, histogramIntervalStart, ts)
+			// Sessions were already flushed; advance their boundary regardless.
+			sessionIntervalStart = ts
+			if err != nil {
 				edm.log.Error("unable to rotate parquet data", "error", err)
 				continue
 			}
+			histogramIntervalStart = ts
 
 			// See if we need to modify anything based on a config update
 			conf = edm.getConfig()
@@ -3084,11 +3113,17 @@ collectorLoop:
 		case req := <-edm.parquetRotationRequestCh:
 			edm.log.Info("dataCollector: manual parquet rotation requested", "rotation_time", req.rotationTime)
 			drainCollectorQueues()
-			err := rotateCollectedData(req.rotationTime)
+			err := rotateCollectedData(sessionIntervalStart, histogramIntervalStart, req.rotationTime)
+			// Sessions were already flushed; advance their boundary regardless.
+			sessionIntervalStart = req.rotationTime
 			req.done <- err
 			if err != nil {
 				edm.log.Error("unable to rotate parquet data", "error", err)
+				continue
 			}
+			// The histogram only rotates on success, so its boundary
+			// advances only once rotateTracker has succeeded.
+			histogramIntervalStart = req.rotationTime
 
 		case <-wkd.stop:
 			// Tell retryer to stop
@@ -3099,8 +3134,13 @@ collectorLoop:
 			// read from it again in this select statement now that
 			// it is closed.
 			wkd.stop = nil
+
 		case <-wkd.retryerDone:
 			edm.log.Info("dataCollector: update retryer is done")
+			drainCollectorQueues()
+			shutdownTime := time.Now().UTC()
+			flushSessions(sessionIntervalStart, shutdownTime)
+			flushHistogram(histogramIntervalStart, shutdownTime)
 			break collectorLoop
 		}
 	}

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -922,15 +922,15 @@ func TestWellKnownDomainUpdatesAndRotation(t *testing.T) {
 		t.Fatal("timed out waiting for update")
 	}
 
-	prev, err := wkd.rotateTracker(edm, path, time.Unix(60, 0))
+	prev, err := wkd.rotateTracker(edm, path, time.Unix(0, 0), time.Unix(60, 0))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !prev.rotationTime.Equal(time.Unix(60, 0)) || len(wkd.m) != 0 {
+	if !prev.startTime.Equal(time.Unix(0, 0)) || !prev.rotationTime.Equal(time.Unix(60, 0)) || len(wkd.m) != 0 {
 		t.Fatalf("unexpected rotation state: %#v", prev)
 	}
 
-	if _, err := wkd.rotateTracker(edm, filepath.Join(t.TempDir(), "missing.dawg"), time.Now()); err == nil {
+	if _, err := wkd.rotateTracker(edm, filepath.Join(t.TempDir(), "missing.dawg"), time.Unix(0, 0), time.Now()); err == nil {
 		t.Fatal("rotateTracker with missing file succeeded")
 	}
 }


### PR DESCRIPTION
## Summary
- drain pending session and histogram updates after the collector stop signal
- flush final session and histogram data before closing writer channels
- preserve the original interval start for shutdown flushes

## Tests
- go test ./pkg/runner ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage verifying proper data flushing on shutdown.

* **Improvements**
  * Enhanced interval start time tracking for sessions and histograms to ensure accurate data synchronization during collection and shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->