### PR TITLE
fix(runner): preserve sub-second minute scheduling

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -2906,7 +2906,11 @@ func (edm *dnstapMinimiser) pseudonymiseIP(ipBytes []byte) ([]byte, error) {
 }
 
 func timeUntilNextMinute() time.Duration {
-	return time.Second * time.Duration(60-time.Now().Second())
+	return timeUntilNextMinuteFrom(time.Now())
+}
+
+func timeUntilNextMinuteFrom(now time.Time) time.Duration {
+	return now.Truncate(time.Minute).Add(time.Minute).Sub(now)
 }
 
 func (edm *dnstapMinimiser) newHistogramData(hllSettings hll.Settings, suffixMatch bool) *histogramData {

--- a/pkg/runner/time_test.go
+++ b/pkg/runner/time_test.go
@@ -1,0 +1,39 @@
+package runner
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimeUntilNextMinuteFrom(t *testing.T) {
+	tests := []struct {
+		name string
+		now  time.Time
+		want time.Duration
+	}{
+		{
+			name: "exact minute",
+			now:  time.Date(2026, 4, 29, 12, 30, 0, 0, time.UTC),
+			want: time.Minute,
+		},
+		{
+			name: "half second after minute",
+			now:  time.Date(2026, 4, 29, 12, 30, 0, 500*int(time.Millisecond), time.UTC),
+			want: 59*time.Second + 500*time.Millisecond,
+		},
+		{
+			name: "one millisecond before next minute",
+			now:  time.Date(2026, 4, 29, 12, 30, 59, int(999*time.Millisecond), time.UTC),
+			want: time.Millisecond,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := timeUntilNextMinuteFrom(tc.now)
+			if got != tc.want {
+				t.Fatalf("duration have: %s, want: %s", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- preserve sub-second timing when calculating the next minute boundary
- avoid truncating wait duration too early
- add focused scheduling tests

## Tests
- go test ./pkg/runner ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal time calculation logic to improve code maintainability and clarity.

* **Tests**
  * Added comprehensive unit tests for time boundary calculations, including edge cases at minute boundaries and intermediate time points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->