### PR TITLE
fix(runner): preserve exact aggregate intervals

### DIFF
--- a/pkg/runner/aggregate_sender.go
+++ b/pkg/runner/aggregate_sender.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -130,10 +129,8 @@ func (as aggregateSender) send(ctx context.Context, fileName string, ts time.Tim
 	req.ContentLength = fileSize
 
 	// Expected by aggrec, e.g:
-	// Aggregate-Interval: 2023-11-16T09:24:13.487591+01:00/PT1M
-	minutesFloat := duration.Minutes()
-	minutes := int(math.Round(minutesFloat))
-	req.Header.Add("Aggregate-Interval", fmt.Sprintf("%s/PT%dM", ts.Truncate(time.Minute).Format(time.RFC3339), minutes))
+	// Aggregate-Interval: 2023-11-16T09:24:13+01:00/PT45S
+	req.Header.Add("Aggregate-Interval", fmt.Sprintf("%s/%s", ts.Format(time.RFC3339), iso8601Duration(duration)))
 
 	as.log.Info("aggregateSender.send", "filename", fileName, "url", histogramURL)
 	startTime := now()
@@ -170,4 +167,41 @@ func (as aggregateSender) send(ctx context.Context, fileName string, ts time.Tim
 	as.log.Info("aggregateSender.send: file uploaded", "elapsed", elapsedTime.String(), "url", locationURL.String())
 
 	return nil
+}
+
+// iso8601Duration formats duration as an ISO 8601 duration string, e.g. "PT1H2M3S".
+//
+// Sub-second precision is preserved as a fractional seconds component.
+// Non-positive durations yield "PT0S".
+func iso8601Duration(duration time.Duration) string {
+	if duration <= 0 {
+		return "PT0S"
+	}
+
+	total := int64(duration / time.Second)
+	nanoseconds := duration % time.Second
+
+	hours := total / 3600
+	total %= 3600
+	minutes := total / 60
+	seconds := total % 60
+
+	res := "PT"
+	if hours > 0 {
+		res += strconv.FormatInt(hours, 10) + "H"
+	}
+	if minutes > 0 {
+		res += strconv.FormatInt(minutes, 10) + "M"
+	}
+	if seconds > 0 || nanoseconds > 0 || res == "PT" {
+		if nanoseconds == 0 {
+			res += strconv.FormatInt(seconds, 10)
+		} else {
+			secondsFloat := float64(seconds) + float64(nanoseconds)/float64(time.Second)
+			res += strconv.FormatFloat(secondsFloat, 'f', -1, 64)
+		}
+		res += "S"
+	}
+
+	return res
 }

--- a/pkg/runner/aggregate_sender_test.go
+++ b/pkg/runner/aggregate_sender_test.go
@@ -85,7 +85,7 @@ func TestAggregateSenderClosesBodyOnReadError(t *testing.T) {
 	}
 
 	start := time.Date(2026, 4, 29, 12, 34, 45, 0, time.UTC)
-	err = as.send(file.Name(), start, 45*time.Second)
+	err = as.send(t.Context(), file.Name(), start, 45*time.Second)
 	if err == nil {
 		t.Fatal("expected error from send when response body is truncated")
 	}
@@ -94,5 +94,87 @@ func TestAggregateSenderClosesBodyOnReadError(t *testing.T) {
 	case <-closed:
 	case <-time.After(2 * time.Second):
 		t.Fatal("server handler did not run")
+	}
+}
+
+func TestISO8601Duration(t *testing.T) {
+	tests := []struct {
+		name string
+		in   time.Duration
+		want string
+	}{
+		{
+			name: "zero",
+			in:   0,
+			want: "PT0S",
+		},
+		{
+			name: "seconds",
+			in:   45 * time.Second,
+			want: "PT45S",
+		},
+		{
+			name: "minutes",
+			in:   time.Minute,
+			want: "PT1M",
+		},
+		{
+			name: "mixed",
+			in:   time.Hour + 2*time.Minute + 3*time.Second,
+			want: "PT1H2M3S",
+		},
+		{
+			name: "fractional seconds",
+			in:   1500 * time.Millisecond,
+			want: "PT1.5S",
+		},
+		{
+			name: "negative clamps to zero",
+			in:   -time.Second,
+			want: "PT0S",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := iso8601Duration(tc.in); got != tc.want {
+				t.Fatalf("have: %s, want: %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAggregateSenderUsesExactIntervalHeader(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	fileName := writeTempFile(t, "aggregate.parquet", []byte("payload"))
+
+	var gotInterval string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotInterval = r.Header.Get("Aggregate-Interval")
+		if _, err := io.Copy(io.Discard, r.Body); err != nil {
+			t.Errorf("reading request body: %s", err)
+		}
+		w.Header().Set("Location", "/stored")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(server.Close)
+
+	aggrecURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %s", err)
+	}
+	as, err := edm.newAggregateSender(aggrecURL, testJWK(t), nil)
+	if err != nil {
+		t.Fatalf("newAggregateSender: %s", err)
+	}
+
+	start := time.Date(2026, 4, 29, 12, 34, 45, 0, time.UTC)
+	if err := as.send(t.Context(), fileName, start, 45*time.Second); err != nil {
+		t.Fatalf("send: %s", err)
+	}
+
+	want := "2026-04-29T12:34:45Z/PT45S"
+	if gotInterval != want {
+		t.Fatalf("Aggregate-Interval header\n  have: %s\n  want: %s", gotInterval, want)
 	}
 }

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -1246,7 +1246,7 @@ func TestAggregateSender(t *testing.T) {
 		if r.Header.Get("Content-Type") != "application/vnd.apache.parquet" {
 			t.Fatalf("content type = %q", r.Header.Get("Content-Type"))
 		}
-		if r.Header.Get("Aggregate-Interval") != "2026-05-28T12:34:00Z/PT2M" {
+		if r.Header.Get("Aggregate-Interval") != "2026-05-28T12:34:56Z/PT2M" {
 			t.Fatalf("aggregate interval = %q", r.Header.Get("Aggregate-Interval"))
 		}
 		body, err := io.ReadAll(r.Body)


### PR DESCRIPTION
## Summary
- preserve exact aggregate interval durations in outbound HTTP headers
- format intervals as ISO-8601 durations instead of rounded minute counts
- add duration and header regression coverage

## Tests
- go test ./pkg/runner ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Aggregate-Interval HTTP header now uses the exact request timestamp and ISO‑8601 duration strings (hours/minutes/seconds with fractional seconds; non‑positive durations clamp to PT0S) for improved accuracy.

* **Tests**
  * Added/updated tests to verify ISO‑8601 duration formatting and that aggregate sender sends the precise Aggregate-Interval header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->