### PR TITLE
fix(aggregateSender): close transport on reload

### DIFF
--- a/pkg/runner/aggregate_sender.go
+++ b/pkg/runner/aggregate_sender.go
@@ -27,6 +27,7 @@ type aggregateSender struct {
 	aggrecURL         *url.URL
 	caCertPool        *x509.CertPool
 	signingHTTPClient *httpsign.Client
+	httpTransport     *http.Transport
 }
 
 func (edm *dnstapMinimiser) newAggregateSender(aggrecURL *url.URL, signingJwk jwk.Key, caCertPool *x509.CertPool) (aggregateSender, error) {
@@ -38,20 +39,21 @@ func (edm *dnstapMinimiser) newAggregateSender(aggrecURL *url.URL, signingJwk jw
 	}
 
 	// Create HTTP handler for sending aggregate files to aggrec
-	httpClient := http.Client{
-		Transport: &http.Transport{
-			DialContext: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-			}).DialContext,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ResponseHeaderTimeout: 10 * time.Second,
-			TLSClientConfig: &tls.Config{
-				RootCAs:              caCertPool,
-				GetClientCertificate: edm.httpClientCertStore.getClientCertificate,
-				MinVersion:           tls.VersionTLS13,
-			},
+	httpTransport := &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 10 * time.Second,
+		TLSClientConfig: &tls.Config{
+			RootCAs:              caCertPool,
+			GetClientCertificate: edm.httpClientCertStore.getClientCertificate,
+			MinVersion:           tls.VersionTLS13,
 		},
+	}
+	httpClient := http.Client{
+		Transport: httpTransport,
 	}
 
 	edm.log.Info("creating HTTP signer", "key_id", signingJwk.KeyID(), "key_alg", signingJwk.Algorithm())
@@ -71,6 +73,7 @@ func (edm *dnstapMinimiser) newAggregateSender(aggrecURL *url.URL, signingJwk jw
 		aggrecURL:         aggrecURL,
 		caCertPool:        caCertPool,
 		signingHTTPClient: client,
+		httpTransport:     httpTransport,
 	}, nil
 }
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -716,11 +716,21 @@ func (edm *dnstapMinimiser) setupHistogramSender() error {
 		}
 	}
 
-	edm.aggregSenderMutex.Lock()
-	edm.aggregSender, err = edm.newAggregateSender(httpURL, httpSigningJwk, httpCACertPool)
-	edm.aggregSenderMutex.Unlock()
+	// Build the new sender first so a failed rebuild leaves the existing
+	// working sender in place instead of zeroing it.
+	newAggregSender, err := edm.newAggregateSender(httpURL, httpSigningJwk, httpCACertPool)
 	if err != nil {
 		return fmt.Errorf("setupHistogramSender: unable to create aggregate sender: %w", err)
+	}
+
+	edm.aggregSenderMutex.Lock()
+	oldAggregSender := edm.aggregSender
+	edm.aggregSender = newAggregSender
+	edm.aggregSenderMutex.Unlock()
+
+	// Close idle connections in the old HTTP client to release resources
+	if oldAggregSender.httpTransport != nil {
+		oldAggregSender.httpTransport.CloseIdleConnections()
 	}
 
 	return nil

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -1805,6 +1805,74 @@ func TestSetupHistogramSenderAndCertLoaders(t *testing.T) {
 	edm.conf.MQTTSigningKeyFile = mqttKeyPath
 }
 
+// TestSetupHistogramSenderClosesOldTransport verifies that reloading the
+// histogram sender retains the previous aggregate sender's transport and
+// closes its idle connections, so reloads do not leak keep-alive connections.
+func TestSetupHistogramSenderClosesOldTransport(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+
+	connStateCh := make(chan http.ConnState, 16)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "/uploaded/hist.parquet")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		select {
+		case connStateCh <- state:
+		default:
+		}
+	}
+	server.Start()
+	t.Cleanup(server.Close)
+
+	edm.conf.HTTPURL = server.URL
+	edm.conf.HTTPSigningKeyFile = testJWKFile(t)
+
+	if err := edm.setupHistogramSender(); err != nil {
+		t.Fatal(err)
+	}
+	oldSender := edm.aggregSender
+	if oldSender.httpTransport == nil {
+		t.Fatal("httpTransport was not retained on the aggregate sender")
+	}
+
+	// Make a request through the old transport so it holds an idle keep-alive
+	// connection that the reload is expected to close.
+	fileName := writeTempFile(t, "hist.parquet", []byte("payload"))
+	if err := oldSender.send(t.Context(), fileName, time.Now(), time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	waitForConnState(t, connStateCh, http.StateIdle)
+
+	// Reloading creates a new sender and must close the old transport's idle
+	// connections without touching the live one.
+	if err := edm.setupHistogramSender(); err != nil {
+		t.Fatal(err)
+	}
+	if edm.aggregSender.httpTransport == oldSender.httpTransport {
+		t.Fatal("reload did not create a new transport")
+	}
+	waitForConnState(t, connStateCh, http.StateClosed)
+}
+
+// waitForConnState blocks until want is observed on ch or the test deadline is
+// reached, failing the test if the state never arrives.
+func waitForConnState(t testing.TB, ch <-chan http.ConnState, want http.ConnState) {
+	t.Helper()
+
+	timeout := time.After(10 * time.Second)
+	for {
+		select {
+		case state := <-ch:
+			if state == want {
+				return
+			}
+		case <-timeout:
+			t.Fatalf("timed out waiting for connection state %s", want)
+		}
+	}
+}
+
 func TestSetupMQTT(t *testing.T) {
 	oldNewAutoPahoConnection := newAutoPahoConnection
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary
- retain the aggregate sender HTTP transport so it can be closed explicitly
- close the previous idle connection pool when aggregate sender config reloads
- avoid leaking reusable HTTP connections across reloads

## Tests
- go test ./pkg/runner ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP connection management during sender reloads: old transport idle keep-alive connections are now closed after a successful swap, and reloads preserve the existing sender on failure to avoid interruptions.

* **Tests**
  * Added a test that verifies idle HTTP connections are closed when the sender is reloaded, ensuring connection pooling is correctly released.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->