### PR TITLE
feat(runner): add pebble sync switch

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -35,6 +35,7 @@ func init() {
 	runCmd.Flags().Bool("disable-mqtt", false, "disable MQTT message sending")
 	runCmd.Flags().Bool("disable-mqtt-filequeue", false, "disable MQTT file based queue")
 	runCmd.Flags().Bool("enable-manual-parquet-rotation", false, "enable localhost HTTP endpoint for manually rotating session and histogram parquet files")
+	runCmd.Flags().Bool("pebble-sync", false, "fsync seen-qname pebble writes")
 
 	runCmd.Flags().String("input-unix", "", "create unix socket for reading dnstap (e.g. /var/lib/unbound/dnstap.sock)")
 	runCmd.Flags().String("input-tcp", "", "create TCP socket for reading dnstap (e.g. '127.0.0.1:53535')")

--- a/pkg/runner/run_minimiser_test.go
+++ b/pkg/runner/run_minimiser_test.go
@@ -1,0 +1,17 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+)
+
+func TestSeenQnameWriteOptions(t *testing.T) {
+	if got := seenQnameWriteOptions(config{}); got != pebble.NoSync {
+		t.Fatalf("default seen-qname write option = %p, want %p", got, pebble.NoSync)
+	}
+
+	if got := seenQnameWriteOptions(config{PebbleSync: true}); got != pebble.Sync {
+		t.Fatalf("pebble-sync seen-qname write option = %p, want %p", got, pebble.Sync)
+	}
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -78,6 +78,7 @@ type config struct {
 	DisableMQTT                   bool   `mapstructure:"disable-mqtt"`
 	DisableMQTTFilequeue          bool   `mapstructure:"disable-mqtt-filequeue"`
 	EnableManualParquetRotation   bool   `mapstructure:"enable-manual-parquet-rotation"`
+	PebbleSync                    bool   `mapstructure:"pebble-sync" reload:"true"`
 	InputUnix                     string `mapstructure:"input-unix" validate:"required_without_all=InputTCP InputTLS,excluded_with=InputTCP InputTLS"`
 	InputTCP                      string `mapstructure:"input-tcp" validate:"required_without_all=InputUnix InputTLS,excluded_with=InputUnix InputTLS"`
 	InputTLS                      string `mapstructure:"input-tls" validate:"required_without_all=InputUnix InputTCP,excluded_with=InputUnix InputTCP"`
@@ -1857,8 +1858,19 @@ func (wkd *wellKnownDomainsTracker) rotateTracker(edm *dnstapMinimiser, dawgFile
 	return prevWKD, nil
 }
 
+// seenQnameWriteOptions selects the pebble write options for seen-qname inserts.
+//
+// It returns [pebble.Sync] when conf.PebbleSync is set so writes are fsynced,
+// and [pebble.NoSync] otherwise.
+func seenQnameWriteOptions(conf config) *pebble.WriteOptions {
+	if conf.PebbleSync {
+		return pebble.Sync
+	}
+	return pebble.NoSync
+}
+
 // Check if we have already seen this qname since we started.
-func (edm *dnstapMinimiser) qnameSeen(msg *dns.Msg, seenQnameLRU *lru.Cache[string, struct{}], pdb *pebble.DB) bool {
+func (edm *dnstapMinimiser) qnameSeen(msg *dns.Msg, seenQnameLRU *lru.Cache[string, struct{}], pdb *pebble.DB, conf config) bool {
 	// NOTE: This looks like it might be a race (calling
 	// Get() followed by separate Add()) but since we want
 	// to keep often looked-up names in the cache we need to
@@ -1893,7 +1905,7 @@ func (edm *dnstapMinimiser) qnameSeen(msg *dns.Msg, seenQnameLRU *lru.Cache[stri
 
 	// If the key does not exist in pebble we insert it
 	if errors.Is(err, pebble.ErrNotFound) {
-		if err := pdb.Set([]byte(qname), []byte{}, pebble.Sync); err != nil {
+		if err := pdb.Set([]byte(qname), []byte{}, seenQnameWriteOptions(conf)); err != nil {
 			edm.log.Error("unable to insert key in pebble", "error", err)
 		}
 		return false
@@ -2047,7 +2059,7 @@ minimiserLoop:
 				continue
 			}
 
-			if !edm.qnameSeen(msg, seenQnameLRU, pdb) {
+			if !edm.qnameSeen(msg, seenQnameLRU, pdb, conf) {
 				if !startConf.DisableMQTT {
 					newQname := protocols.NewQnameEvent(msg, truncatedTimestamp)
 

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -875,10 +875,10 @@ func TestQnameSeen(t *testing.T) {
 
 	msg := new(dns.Msg)
 	msg.SetQuestion("Example.COM.", dns.TypeA)
-	if edm.qnameSeen(msg, cache, db) {
+	if edm.qnameSeen(msg, cache, db, defaultTC.config) {
 		t.Fatal("first qnameSeen call returned true")
 	}
-	if !edm.qnameSeen(msg, cache, db) {
+	if !edm.qnameSeen(msg, cache, db, defaultTC.config) {
 		t.Fatal("second qnameSeen call returned false")
 	}
 
@@ -886,13 +886,13 @@ func TestQnameSeen(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !edm.qnameSeen(msg, cache, db) {
+	if !edm.qnameSeen(msg, cache, db, defaultTC.config) {
 		t.Fatal("qnameSeen did not find qname in pebble")
 	}
 
 	other := new(dns.Msg)
 	other.SetQuestion("other.example.", dns.TypeA)
-	_ = edm.qnameSeen(other, cache, db)
+	_ = edm.qnameSeen(other, cache, db, defaultTC.config)
 }
 
 func TestWellKnownDomainUpdatesAndRotation(t *testing.T) {
@@ -1138,7 +1138,7 @@ func TestQnameSeenLRUEviction(t *testing.T) {
 
 	first := new(dns.Msg)
 	first.SetQuestion("a.example.", dns.TypeA)
-	if edm.qnameSeen(first, cache, db) {
+	if edm.qnameSeen(first, cache, db, defaultTC.config) {
 		t.Fatal("first qname unexpectedly already-seen")
 	}
 
@@ -1146,7 +1146,7 @@ func TestQnameSeenLRUEviction(t *testing.T) {
 	second.SetQuestion("b.example.", dns.TypeA)
 	// Adding the second distinct qname evicts the first from the LRU,
 	// exercising the evicted/promSeenQnameLRUEvicted.Inc() arm.
-	_ = edm.qnameSeen(second, cache, db)
+	_ = edm.qnameSeen(second, cache, db, defaultTC.config)
 	if cache.Len() != 1 {
 		t.Fatalf("cache len = %d, want 1 after eviction", cache.Len())
 	}


### PR DESCRIPTION
## Summary
- add --pebble-sync / pebble-sync config support
- use NoSync for seen-qname writes by default and allow operators to opt into Sync
- add write option coverage

## Tests
- go test ./pkg/cmd ./pkg/runner ./...