### PR TITLE
feat(runner): tune minimiser hot path buffers

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -91,7 +91,7 @@ type config struct {
 	IgnoredClientIPsFile          string `mapstructure:"ignored-client-ips-file" reload:"true"`
 	IgnoredQuestionNamesFile      string `mapstructure:"ignored-question-names-file" reload:"true"`
 	DataDir                       string `mapstructure:"data-dir" validate:"required"`
-	MinimiserWorkers              int    `mapstructure:"minimiser-workers" validate:"required"`
+	MinimiserWorkers              int    `mapstructure:"minimiser-workers"`
 	MQTTSigningKeyFile            string `mapstructure:"mqtt-signing-key-file" validate:"required_without=DisableMQTT"`
 	MQTTClientKeyFile             string `mapstructure:"mqtt-client-key-file" validate:"required_without=DisableMQTT" reload:"true"`
 	MQTTClientCertFile            string `mapstructure:"mqtt-client-cert-file" validate:"required_without=DisableMQTT" reload:"true"`
@@ -1616,9 +1616,10 @@ func newDnstapMinimiser(logger *slog.Logger, edmConf edmConfiger) (*dnstapMinimi
 	})
 
 	edm.promReg = promReg
-	// Size 32 matches unexported "const outputChannelSize = 32" in
-	// https://github.com/dnstap/golang-dnstap/blob/master/dnstap.go
-	edm.inputChannel = make(chan []byte, 32)
+	// Buffer enough frames to absorb scheduling jitter under high QPS.
+	// A 1024-frame buffer keeps producers from stalling without growing
+	// memory meaningfully for typical dnstap frame sizes.
+	edm.inputChannel = make(chan []byte, 1024)
 	edm.log = logger
 	edm.debug = conf.Debug
 
@@ -1961,6 +1962,11 @@ func (edm *dnstapMinimiser) runMinimiser(minimiserID int, wg *sync.WaitGroup, se
 
 	dt := &dnstap.Dnstap{}
 
+	// Per-worker scratch buffer for the unpseudonymised client IP we pass
+	// to wkdTracker.sendUpdate for HLL hashing. Sized to fit IPv6 and
+	// resliced to len(QueryAddress) per frame.
+	var dangerScratch [16]byte
+
 	// startConf is used for things that do not handle reconfiguration at runtime
 	startConf := edm.getConfig()
 
@@ -2004,8 +2010,17 @@ minimiserLoop:
 
 			// Keep around the unpseudonymised client IP for HLL
 			// data, be careful with logging or otherwise handling
-			// this IP as it is sensitive.
-			dangerRealClientIP := make([]byte, len(dt.Message.QueryAddress))
+			// this IP as it is sensitive. Borrow the per-worker
+			// scratch buffer, falling back to allocation only for an
+			// address longer than the scratch buffer (IPv4 and IPv6
+			// both fit).
+			n := len(dt.Message.QueryAddress)
+			var dangerRealClientIP []byte
+			if n <= len(dangerScratch) {
+				dangerRealClientIP = dangerScratch[:n]
+			} else {
+				dangerRealClientIP = make([]byte, n)
+			}
 			copy(dangerRealClientIP, dt.Message.QueryAddress)
 
 			edm.pseudonymiseDnstap(dt)

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -2356,6 +2356,61 @@ func TestRunMinimiserFlows(t *testing.T) {
 	wg.Wait()
 }
 
+// TestRunMinimiserScratchClientIP verifies that the per-worker scratch buffer
+// used to keep the unpseudonymised client IP yields the correct raw address
+// for every frame, even when a single worker processes consecutive frames of
+// different address families. It feeds an IPv4 frame followed by an IPv6 frame
+// (which fills the scratch buffer completely) and checks that each emitted
+// wkdUpdate carries the original client IP and its matching HLL hash, proving
+// the IP is captured before pseudonymisation and that reusing the scratch
+// buffer does not corrupt earlier or later frames.
+func TestRunMinimiserScratchClientIP(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	edm.reloadMinimiserConfigCh = []chan struct{}{make(chan struct{}, 1)}
+	edm.newQnamePublisherCh = make(chan *protocols.NewQnameJSON, 1)
+	edm.sessionCollectorCh = make(chan *sessionData, 1)
+	cache, err := lru.New[string, struct{}](2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := newTestPebble(t)
+	wkd, err := newWellKnownDomainsTracker(testDawgFinder(t, "known.example."), time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go edm.runMinimiser(0, &wg, cache, db, nil, defaultLabelLimit, wkd)
+
+	tests := []struct {
+		family dnstap.SocketFamily
+		ip     netip.Addr
+	}{
+		{dnstap.SocketFamily_INET, netip.MustParseAddr("198.51.100.20")},
+		{dnstap.SocketFamily_INET6, netip.MustParseAddr("2001:db8::20")},
+	}
+	for _, tc := range tests {
+		frame := marshaledDnstap(t, testDnstapMessage(t, dnstap.Message_CLIENT_RESPONSE, tc.family, packedDNSMsg(t, "known.example.", dns.TypeA, dns.RcodeSuccess)))
+		edm.inputChannel <- frame
+		select {
+		case wu := <-wkd.updateCh:
+			if wu.ip != tc.ip {
+				t.Fatalf("client IP for %s: got %s, want %s", tc.family, wu.ip, tc.ip)
+			}
+			wantHash := murmur3.Sum64(tc.ip.AsSlice())
+			if wu.hllHash != wantHash {
+				t.Fatalf("HLL hash for %s: got %d, want %d", tc.family, wu.hllHash, wantHash)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for WKD update for %s", tc.family)
+		}
+	}
+
+	edm.stop()
+	wg.Wait()
+}
+
 func TestRunMinimiserParseAndIgnoreFlows(t *testing.T) {
 	edm := newTestDnstapMinimiser(t, defaultTC)
 	edm.reloadMinimiserConfigCh = []chan struct{}{make(chan struct{}, 1)}


### PR DESCRIPTION
## Summary
- increase the dnstap input buffer to reduce producer stalls under high packet rates
- reuse a per-worker scratch buffer for client IP HLL hashing
- allow minimiser-workers=0 to reach the existing GOMAXPROCS fallback

## Tests
- go test ./pkg/runner ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Increased input buffer capacity to better absorb scheduling variations
  * Optimized client IP address handling to reduce memory allocations during processing

* **Tests**
  * Added comprehensive test coverage for client IP address handling and preservation in minimiser operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->