### PR TITLE
feat(runner): add manual parquet rotation endpoint

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -34,6 +34,7 @@ func init() {
 	runCmd.Flags().Bool("disable-histogram-sender", false, "do not check for histogram files to upload to core")
 	runCmd.Flags().Bool("disable-mqtt", false, "disable MQTT message sending")
 	runCmd.Flags().Bool("disable-mqtt-filequeue", false, "disable MQTT file based queue")
+	runCmd.Flags().Bool("enable-manual-parquet-rotation", false, "enable localhost HTTP endpoint for manually rotating session and histogram parquet files")
 
 	runCmd.Flags().String("input-unix", "", "create unix socket for reading dnstap (e.g. /var/lib/unbound/dnstap.sock)")
 	runCmd.Flags().String("input-tcp", "", "create TCP socket for reading dnstap (e.g. '127.0.0.1:53535')")

--- a/pkg/runner/manual_parquet_rotation_test.go
+++ b/pkg/runner/manual_parquet_rotation_test.go
@@ -1,0 +1,196 @@
+package runner
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"path/filepath"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/smhanov/dawg"
+	"github.com/spaolacci/murmur3"
+)
+
+func TestDataCollectorManualParquetRotationFlushesPendingData(t *testing.T) {
+	edm, wkdTracker, dawgFile := newManualParquetRotationTestFixture(t, "example.com.")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go edm.dataCollector(&wg, wkdTracker, dawgFile)
+
+	serverID := "serverID"
+	edm.sessionCollectorCh <- &sessionData{ServerID: &serverID}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeA)
+	ip := netip.MustParseAddr("198.51.100.10")
+	dawgIndex, suffixMatch, dawgModTime := wkdTracker.lookup(msg)
+	wkdTracker.updateCh <- wkdUpdate{
+		dawgIndex:   dawgIndex,
+		suffixMatch: suffixMatch,
+		dawgModTime: dawgModTime,
+		histogramData: histogramData{
+			ACount:  1,
+			OKCount: 1,
+		},
+		hllHash: murmur3.Sum64(ip.AsSlice()),
+		ip:      ip,
+	}
+
+	rotationTime := time.Now().UTC().Add(time.Second)
+	req := parquetRotationRequest{
+		rotationTime: rotationTime,
+		done:         make(chan error, 1),
+	}
+	edm.parquetRotationRequestCh <- req
+
+	select {
+	case err := <-req.done:
+		if err != nil {
+			t.Fatalf("manual parquet rotation failed: %s", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("manual parquet rotation timed out")
+	}
+
+	ps, ok := <-edm.sessionWriterCh
+	if !ok {
+		t.Fatal("sessionWriterCh closed without manual session flush")
+	}
+	if len(ps.sessions) != 1 {
+		t.Fatalf("manual session flush has: %d, want: 1", len(ps.sessions))
+	}
+	if !ps.rotationTime.Equal(rotationTime) {
+		t.Fatalf("manual session rotation time have: %s, want: %s", ps.rotationTime, rotationTime)
+	}
+
+	prevWKD, ok := <-edm.histogramWriterCh
+	if !ok {
+		t.Fatal("histogramWriterCh closed without manual histogram flush")
+	}
+	if !prevWKD.rotationTime.Equal(rotationTime) {
+		t.Fatalf("manual histogram rotation time have: %s, want: %s", prevWKD.rotationTime, rotationTime)
+	}
+	got := prevWKD.m[dawgIndex]
+	if got == nil {
+		t.Fatalf("manual histogram flush missing DAWG index %d", dawgIndex)
+	}
+	if got.ACount != 1 || got.OKCount != 1 {
+		t.Fatalf("manual histogram counts have A=%d OK=%d, want A=1 OK=1", got.ACount, got.OKCount)
+	}
+
+	close(wkdTracker.stop)
+	waitForWaitGroup(t, &wg, 2*time.Second, "dataCollector did not exit after stop")
+}
+
+func TestManualParquetRotationHandlerRejectsNonPost(t *testing.T) {
+	edm := newManualParquetRotationTestMinimiser(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/debug/rotate-parquet", nil)
+	edm.manualParquetRotationHandler(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status have: %d, want: %d", rec.Code, http.StatusMethodNotAllowed)
+	}
+	if allow := rec.Header().Get("Allow"); allow != http.MethodPost {
+		t.Fatalf("Allow header have: %q, want: %q", allow, http.MethodPost)
+	}
+}
+
+func TestManualParquetRotationHandlerAcceptsCompletedRotation(t *testing.T) {
+	edm := newManualParquetRotationTestMinimiser(t)
+
+	rotationHandled := make(chan struct{})
+	go func() {
+		req := <-edm.parquetRotationRequestCh
+		if req.rotationTime.IsZero() {
+			t.Error("rotation request should include a timestamp")
+		}
+		req.done <- nil
+		close(rotationHandled)
+	}()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/debug/rotate-parquet", nil)
+	edm.manualParquetRotationHandler(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status have: %d, want: %d", rec.Code, http.StatusAccepted)
+	}
+
+	select {
+	case <-rotationHandled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not send a parquet rotation request")
+	}
+}
+
+func newManualParquetRotationTestFixture(t *testing.T, domains ...string) (*dnstapMinimiser, *wellKnownDomainsTracker, string) {
+	t.Helper()
+
+	edm := newManualParquetRotationTestMinimiser(t)
+	dawgFile, dawgFinder := writeManualParquetRotationTestDawgFile(t, domains...)
+	wkdTracker, err := newWellKnownDomainsTracker(dawgFinder, time.Time{})
+	if err != nil {
+		t.Fatalf("newWellKnownDomainsTracker: %s", err)
+	}
+
+	return edm, wkdTracker, dawgFile
+}
+
+func newManualParquetRotationTestMinimiser(t *testing.T) *dnstapMinimiser {
+	t.Helper()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	edm, err := newDnstapMinimiser(logger, defaultTC)
+	if err != nil {
+		t.Fatalf("newDnstapMinimiser: %s", err)
+	}
+	t.Cleanup(func() {
+		edm.stop()
+		if edm.fsWatcher != nil {
+			_ = edm.fsWatcher.Close()
+		}
+	})
+
+	return edm
+}
+
+func writeManualParquetRotationTestDawgFile(t *testing.T, domains ...string) (string, dawg.Finder) {
+	t.Helper()
+
+	slices.Sort(domains)
+	builder := dawg.New()
+	for _, domain := range domains {
+		builder.Add(domain)
+	}
+	finder := builder.Finish()
+	path := filepath.Join(t.TempDir(), "well-known-domains.dawg")
+	if _, err := finder.Save(path); err != nil {
+		t.Fatalf("dawg.Save: %s", err)
+	}
+	return path, finder
+}
+
+func waitForWaitGroup(t *testing.T, wg *sync.WaitGroup, timeout time.Duration, msg string) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatal(msg)
+	}
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -70,6 +70,7 @@ type config struct {
 	DisableHistogramSender        bool   `mapstructure:"disable-histogram-sender" reload:"true"`
 	DisableMQTT                   bool   `mapstructure:"disable-mqtt"`
 	DisableMQTTFilequeue          bool   `mapstructure:"disable-mqtt-filequeue"`
+	EnableManualParquetRotation   bool   `mapstructure:"enable-manual-parquet-rotation"`
 	InputUnix                     string `mapstructure:"input-unix" validate:"required_without_all=InputTCP InputTLS,excluded_with=InputTCP InputTLS"`
 	InputTCP                      string `mapstructure:"input-tcp" validate:"required_without_all=InputUnix InputTLS,excluded_with=InputUnix InputTLS"`
 	InputTLS                      string `mapstructure:"input-tls" validate:"required_without_all=InputUnix InputTCP,excluded_with=InputUnix InputTCP"`
@@ -252,6 +253,11 @@ type sessionData struct {
 type prevSessions struct {
 	sessions     []*sessionData
 	rotationTime time.Time
+}
+
+type parquetRotationRequest struct {
+	rotationTime time.Time
+	done         chan error
 }
 
 type certStore struct {
@@ -1296,6 +1302,9 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 
 	// Setup custom promHandler since we want to use our per-edm registry
 	metricsMux.Handle("/metrics", promhttp.InstrumentMetricHandler(edm.promReg, promhttp.HandlerFor(edm.promReg, promhttp.HandlerOpts{Registry: edm.promReg})))
+	if startConf.EnableManualParquetRotation {
+		metricsMux.HandleFunc("/debug/rotate-parquet", edm.manualParquetRotationHandler)
+	}
 	go func() {
 		err := metricsServer.ListenAndServe()
 		logger.Error("metricsServer failed", "error", err)
@@ -1450,6 +1459,7 @@ type dnstapMinimiser struct {
 	debug                         bool               // if we should print debug messages during operation
 	sessionWriterCh               chan *prevSessions
 	histogramWriterCh             chan *wellKnownDomainsData
+	parquetRotationRequestCh      chan parquetRotationRequest
 	newQnamePublisherCh           chan *protocols.NewQnameJSON
 	sessionCollectorCh            chan *sessionData
 	aggregSenderMutex             sync.RWMutex
@@ -1614,6 +1624,7 @@ func newDnstapMinimiser(logger *slog.Logger, edmConf edmConfiger) (*dnstapMinimi
 	// minimiser loop, otherwise the program can hang on shutdown.
 	edm.sessionWriterCh = make(chan *prevSessions, 100)
 	edm.histogramWriterCh = make(chan *wellKnownDomainsData, 100)
+	edm.parquetRotationRequestCh = make(chan parquetRotationRequest, 1)
 	edm.newQnamePublisherCh = make(chan *protocols.NewQnameJSON, conf.NewQnameBuffer)
 	edm.sessionCollectorCh = make(chan *sessionData, 100)
 
@@ -2314,6 +2325,42 @@ func (edm *dnstapMinimiser) histogramWriter(labelLimit int, outboxDir string, wg
 	edm.log.Info("histogramWriter: exiting loop")
 }
 
+func (edm *dnstapMinimiser) manualParquetRotationHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	req := parquetRotationRequest{
+		rotationTime: time.Now().UTC(),
+		done:         make(chan error, 1),
+	}
+
+	select {
+	case edm.parquetRotationRequestCh <- req:
+	case <-edm.ctx.Done():
+		http.Error(w, "edm is shutting down", http.StatusServiceUnavailable)
+		return
+	case <-r.Context().Done():
+		return
+	}
+
+	select {
+	case err := <-req.done:
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte("rotation requested\n"))
+	case <-time.After(10 * time.Second):
+		http.Error(w, "timed out waiting for parquet rotation", http.StatusGatewayTimeout)
+	case <-r.Context().Done():
+		return
+	}
+}
+
 func (edm *dnstapMinimiser) renameFile(src string, dst string) error {
 	dstDir := filepath.Dir(dst)
 
@@ -2918,79 +2965,112 @@ func (edm *dnstapMinimiser) dataCollector(wg *sync.WaitGroup, wkd *wellKnownDoma
 
 	hllSettings := getHllDefaults(conf.HistogramHLLExplicitThreshold)
 
+	processSession := func(sd *sessionData) {
+		if sd == nil {
+			return
+		}
+		sessions = append(sessions, sd)
+		sessionUpdated = true
+	}
+
+	flushSessions := func(rotationTime time.Time) {
+		if !sessionUpdated {
+			return
+		}
+		ps := &prevSessions{
+			sessions:     sessions,
+			rotationTime: rotationTime,
+		}
+		sessions = []*sessionData{}
+		sessionUpdated = false
+		edm.sessionWriterCh <- ps
+	}
+
+	processWKDUpdate := func(wu wkdUpdate) {
+		// It is possible an update sitting in the queue has
+		// been created with an outdated dawgModTime due to a
+		// call to rotateTracker(). If this is the case we need
+		// to do a new lookup against the new dawg to make sure
+		// we have the correct index number (or if it is even
+		// present in the new dawg).
+		if wu.dawgModTime != wkd.dawgModTime {
+			if !retryChannelClosed {
+				wkd.retryCh <- wu
+			} else {
+				edm.log.Info("discarding retry of wkd update because we are shutting down")
+			}
+			return
+		}
+
+		if _, exists := wkd.m[wu.dawgIndex]; !exists {
+			wkd.m[wu.dawgIndex] = edm.newHistogramData(hllSettings, wu.suffixMatch)
+		}
+
+		wkd.m[wu.dawgIndex].OKCount += wu.OKCount
+		wkd.m[wu.dawgIndex].NXCount += wu.NXCount
+		wkd.m[wu.dawgIndex].FailCount += wu.FailCount
+		wkd.m[wu.dawgIndex].ACount += wu.ACount
+		wkd.m[wu.dawgIndex].AAAACount += wu.AAAACount
+		wkd.m[wu.dawgIndex].MXCount += wu.MXCount
+		wkd.m[wu.dawgIndex].NSCount += wu.NSCount
+		wkd.m[wu.dawgIndex].OtherTypeCount += wu.OtherTypeCount
+		wkd.m[wu.dawgIndex].OtherRcodeCount += wu.OtherRcodeCount
+		wkd.m[wu.dawgIndex].NonINCount += wu.NonINCount
+
+		if wu.ip.IsValid() {
+			if wu.ip.Unmap().Is4() {
+				wkd.m[wu.dawgIndex].v4ClientHLL.AddRaw(wu.hllHash)
+			} else {
+				wkd.m[wu.dawgIndex].v6ClientHLL.AddRaw(wu.hllHash)
+			}
+		}
+	}
+
+	drainCollectorQueues := func() {
+		for {
+			select {
+			case sd := <-edm.sessionCollectorCh:
+				processSession(sd)
+			case wu := <-wkd.updateCh:
+				processWKDUpdate(wu)
+			default:
+				return
+			}
+		}
+	}
+
+	rotateCollectedData := func(rotationTime time.Time) error {
+		flushSessions(rotationTime)
+
+		prevWKD, err := wkd.rotateTracker(edm, dawgFile, rotationTime)
+		if err != nil {
+			return fmt.Errorf("unable to rotate histogram map: %w", err)
+		}
+
+		// Only write out parquet file if there is something to write.
+		if len(prevWKD.m) > 0 {
+			edm.histogramWriterCh <- prevWKD
+		}
+
+		return nil
+	}
+
 collectorLoop:
 	for {
 		select {
 		case sd := <-edm.sessionCollectorCh:
-			sessions = append(sessions, sd)
-			sessionUpdated = true
+			processSession(sd)
 
 		case wu := <-wkd.updateCh:
-			// It is possible an update sitting in the queue has
-			// been created with an outdated dawgModTime due to a
-			// call to rotateTracker(). If this is the case we need
-			// to do a new lookup against the new dawg to make sure
-			// we have the correct index number (or if it is even
-			// present in the new dawg).
-			if wu.dawgModTime != wkd.dawgModTime {
-				if !retryChannelClosed {
-					wkd.retryCh <- wu
-				} else {
-					edm.log.Info("discarding retry of wkd update because we are shutting down")
-				}
-				continue
-			}
-
-			if _, exists := wkd.m[wu.dawgIndex]; !exists {
-				wkd.m[wu.dawgIndex] = edm.newHistogramData(hllSettings, wu.suffixMatch)
-			}
-
-			wkd.m[wu.dawgIndex].OKCount += wu.OKCount
-			wkd.m[wu.dawgIndex].NXCount += wu.NXCount
-			wkd.m[wu.dawgIndex].FailCount += wu.FailCount
-			wkd.m[wu.dawgIndex].ACount += wu.ACount
-			wkd.m[wu.dawgIndex].AAAACount += wu.AAAACount
-			wkd.m[wu.dawgIndex].MXCount += wu.MXCount
-			wkd.m[wu.dawgIndex].NSCount += wu.NSCount
-			wkd.m[wu.dawgIndex].OtherTypeCount += wu.OtherTypeCount
-			wkd.m[wu.dawgIndex].OtherRcodeCount += wu.OtherRcodeCount
-			wkd.m[wu.dawgIndex].NonINCount += wu.NonINCount
-
-			if wu.ip.IsValid() {
-				if wu.ip.Unmap().Is4() {
-					wkd.m[wu.dawgIndex].v4ClientHLL.AddRaw(wu.hllHash)
-				} else {
-					wkd.m[wu.dawgIndex].v6ClientHLL.AddRaw(wu.hllHash)
-				}
-			}
+			processWKDUpdate(wu)
 
 		case ts := <-ticker.C:
 			// We want to tick at the start of each minute
 			ticker.Reset(timeUntilNextMinute())
 
-			if sessionUpdated {
-				ps := &prevSessions{
-					sessions:     sessions,
-					rotationTime: ts,
-				}
-
-				sessions = []*sessionData{}
-
-				// We have reset the sessions slice
-				sessionUpdated = false
-
-				edm.sessionWriterCh <- ps
-			}
-
-			prevWKD, err := wkd.rotateTracker(edm, dawgFile, ts)
-			if err != nil {
-				edm.log.Error("unable to rotate histogram map", "error", err)
+			if err := rotateCollectedData(ts); err != nil {
+				edm.log.Error("unable to rotate parquet data", "error", err)
 				continue
-			}
-
-			// Only write out parquet file if there is something to write
-			if len(prevWKD.m) > 0 {
-				edm.histogramWriterCh <- prevWKD
 			}
 
 			// See if we need to modify anything based on a config update
@@ -2999,6 +3079,15 @@ collectorLoop:
 			if conf.HistogramHLLExplicitThreshold != hllSettings.ExplicitThreshold {
 				edm.log.Info("updating HLL explicit threshold based on config change", "from", hllSettings.ExplicitThreshold, "to", conf.HistogramHLLExplicitThreshold)
 				hllSettings.ExplicitThreshold = conf.HistogramHLLExplicitThreshold
+			}
+
+		case req := <-edm.parquetRotationRequestCh:
+			edm.log.Info("dataCollector: manual parquet rotation requested", "rotation_time", req.rotationTime)
+			drainCollectorQueues()
+			err := rotateCollectedData(req.rotationTime)
+			req.done <- err
+			if err != nil {
+				edm.log.Error("unable to rotate parquet data", "error", err)
 			}
 
 		case <-wkd.stop:

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -64,6 +64,11 @@ var validate = validator.New(validator.WithRequiredStructEnabled())
 // Labels 0-9
 const defaultLabelLimit = 10
 
+const (
+	metricsServerWriteTimeout        = 10 * time.Second
+	manualParquetRotationWaitTimeout = metricsServerWriteTimeout - time.Second
+)
+
 type config struct {
 	ConfigFile                    string `mapstructure:"config-file" validate:"required"`
 	DisableSessionFiles           bool   `mapstructure:"disable-session-files"`
@@ -1296,7 +1301,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 		Addr:           "127.0.0.1:2112",
 		Handler:        metricsMux,
 		ReadTimeout:    10 * time.Second,
-		WriteTimeout:   10 * time.Second,
+		WriteTimeout:   metricsServerWriteTimeout,
 		MaxHeaderBytes: 1 << 20,
 	}
 
@@ -2354,7 +2359,7 @@ func (edm *dnstapMinimiser) manualParquetRotationHandler(w http.ResponseWriter, 
 		}
 		w.WriteHeader(http.StatusAccepted)
 		_, _ = w.Write([]byte("rotation requested\n"))
-	case <-time.After(10 * time.Second):
+	case <-time.After(manualParquetRotationWaitTimeout):
 		http.Error(w, "timed out waiting for parquet rotation", http.StatusGatewayTimeout)
 	case <-r.Context().Done():
 		return


### PR DESCRIPTION
## Summary

- add `--enable-manual-parquet-rotation` as a startup-only flag
- register `POST /debug/rotate-parquet` on the existing localhost metrics server when enabled
- route manual requests through `dataCollector`, draining pending collector queues before rotating session and histogram parquet data
- isolate only the latest manual parquet rotation feature from the fork; this PR intentionally excludes the older fork PR queue

## Validation

- `go test ./...`
- `make test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--enable-manual-parquet-rotation` CLI flag (disabled by default) for opt-in manual parquet rotation
  * Added HTTP debug endpoint (`POST /debug/rotate-parquet`) to trigger parquet rotation on-demand with appropriate response codes for different scenarios

* **Tests**
  * Added comprehensive test coverage for manual parquet rotation functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnstapir/edm/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->