### PR TITLE
test: lock in pkg behavior

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -12,6 +12,17 @@ var (
 	cfgFile        string
 	edmLogger      *slog.Logger
 	edmLoggerLevel *slog.LevelVar
+	exitProcess    = os.Exit
+	userHomeDir    = os.UserHomeDir
+
+	viperSetConfigFile  = viper.SetConfigFile
+	viperAddConfigPath  = viper.AddConfigPath
+	viperSetConfigType  = viper.SetConfigType
+	viperSetConfigName  = viper.SetConfigName
+	viperAutomaticEnv   = viper.AutomaticEnv
+	viperReadInConfig   = viper.ReadInConfig
+	viperConfigFileUsed = viper.ConfigFileUsed
+	viperWatchConfig    = viper.WatchConfig
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -33,7 +44,7 @@ func Execute(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 	edmLoggerLevel = loggerLevel
 	err := rootCmd.Execute()
 	if err != nil {
-		os.Exit(1)
+		exitProcess(1)
 	}
 }
 
@@ -55,25 +66,25 @@ func init() {
 func initConfig() {
 	if cfgFile != "" {
 		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
+		viperSetConfigFile(cfgFile)
 	} else {
 		// Find home directory.
-		home, err := os.UserHomeDir()
+		home, err := userHomeDir()
 		cobra.CheckErr(err)
 
 		// Search config in home directory with name ".edm" (without extension).
-		viper.AddConfigPath(home)
-		viper.SetConfigType("toml")
-		viper.SetConfigName(".dnstapir-edm")
+		viperAddConfigPath(home)
+		viperSetConfigType("toml")
+		viperSetConfigName(".dnstapir-edm")
 	}
 
-	viper.AutomaticEnv() // read in environment variables that match
+	viperAutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		edmLogger.Info("using config file", "filename", viper.ConfigFileUsed())
+	if err := viperReadInConfig(); err == nil {
+		edmLogger.Info("using config file", "filename", viperConfigFileUsed())
 	}
 
 	// Make it so we can detect changes to the cryptopan secret in the config
-	viper.WatchConfig()
+	viperWatchConfig()
 }

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func testLogger() (*slog.Logger, *slog.LevelVar) {
+	level := new(slog.LevelVar)
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: level})), level
+}
+
+func restoreCmdGlobals(t *testing.T) {
+	t.Helper()
+
+	oldCfgFile := cfgFile
+	oldLogger := edmLogger
+	oldLoggerLevel := edmLoggerLevel
+	oldExitProcess := exitProcess
+	oldRunRunner := runRunner
+	oldUserHomeDir := userHomeDir
+	oldSetConfigFile := viperSetConfigFile
+	oldAddConfigPath := viperAddConfigPath
+	oldSetConfigType := viperSetConfigType
+	oldSetConfigName := viperSetConfigName
+	oldAutomaticEnv := viperAutomaticEnv
+	oldReadInConfig := viperReadInConfig
+	oldConfigFileUsed := viperConfigFileUsed
+	oldWatchConfig := viperWatchConfig
+
+	t.Cleanup(func() {
+		cfgFile = oldCfgFile
+		edmLogger = oldLogger
+		edmLoggerLevel = oldLoggerLevel
+		exitProcess = oldExitProcess
+		runRunner = oldRunRunner
+		userHomeDir = oldUserHomeDir
+		viperSetConfigFile = oldSetConfigFile
+		viperAddConfigPath = oldAddConfigPath
+		viperSetConfigType = oldSetConfigType
+		viperSetConfigName = oldSetConfigName
+		viperAutomaticEnv = oldAutomaticEnv
+		viperReadInConfig = oldReadInConfig
+		viperConfigFileUsed = oldConfigFileUsed
+		viperWatchConfig = oldWatchConfig
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+}
+
+func TestInitConfigExplicitFile(t *testing.T) {
+	restoreCmdGlobals(t)
+	logger, level := testLogger()
+	edmLogger = logger
+	edmLoggerLevel = level
+	cfgFile = "/tmp/dnstapir-edm-test.toml"
+
+	var setFile string
+	var automaticEnvCalled bool
+	var watchCalled bool
+	viperSetConfigFile = func(file string) { setFile = file }
+	viperAutomaticEnv = func() { automaticEnvCalled = true }
+	viperReadInConfig = func() error { return nil }
+	viperConfigFileUsed = func() string { return cfgFile }
+	viperWatchConfig = func() { watchCalled = true }
+
+	initConfig()
+
+	if setFile != cfgFile {
+		t.Fatalf("SetConfigFile = %q, want %q", setFile, cfgFile)
+	}
+	if !automaticEnvCalled {
+		t.Fatal("AutomaticEnv was not called")
+	}
+	if !watchCalled {
+		t.Fatal("WatchConfig was not called")
+	}
+}
+
+func TestInitConfigDefaultHomeNoConfig(t *testing.T) {
+	restoreCmdGlobals(t)
+	logger, level := testLogger()
+	edmLogger = logger
+	edmLoggerLevel = level
+	cfgFile = ""
+
+	var addPath, configType, configName string
+	userHomeDir = func() (string, error) { return "/home/tester", nil }
+	viperAddConfigPath = func(path string) { addPath = path }
+	viperSetConfigType = func(value string) { configType = value }
+	viperSetConfigName = func(value string) { configName = value }
+	viperAutomaticEnv = func() {}
+	viperReadInConfig = func() error { return errors.New("not found") }
+	viperWatchConfig = func() {}
+
+	initConfig()
+
+	if addPath != "/home/tester" {
+		t.Fatalf("AddConfigPath = %q", addPath)
+	}
+	if configType != "toml" {
+		t.Fatalf("SetConfigType = %q", configType)
+	}
+	if configName != ".dnstapir-edm" {
+		t.Fatalf("SetConfigName = %q", configName)
+	}
+}
+
+func TestExecuteSuccessAndError(t *testing.T) {
+	restoreCmdGlobals(t)
+	logger, level := testLogger()
+
+	viperAutomaticEnv = func() {}
+	viperReadInConfig = func() error { return errors.New("not found") }
+	viperWatchConfig = func() {}
+
+	rootCmd.SetOut(io.Discard)
+	rootCmd.SetErr(io.Discard)
+	rootCmd.SetArgs([]string{"--help"})
+	Execute(logger, level)
+	if edmLogger != logger || edmLoggerLevel != level {
+		t.Fatal("Execute did not store logger globals")
+	}
+
+	var exitCode int
+	exitProcess = func(code int) { exitCode = code }
+	rootCmd.SetArgs([]string{"unknown-command"})
+	Execute(logger, level)
+	if exitCode != 1 {
+		t.Fatalf("exit code = %d, want 1", exitCode)
+	}
+}
+
+func TestRunCommandUsesRunnerSeam(t *testing.T) {
+	restoreCmdGlobals(t)
+	logger, level := testLogger()
+	edmLogger = logger
+	edmLoggerLevel = level
+
+	var gotLogger *slog.Logger
+	var gotLevel *slog.LevelVar
+	runRunner = func(logger *slog.Logger, loggerLevel *slog.LevelVar) {
+		gotLogger = logger
+		gotLevel = loggerLevel
+	}
+
+	runCmd.Run(&cobra.Command{}, nil)
+	if gotLogger != logger || gotLevel != level {
+		t.Fatalf("runRunner called with logger %p/%p, want %p/%p", gotLogger, gotLevel, logger, level)
+	}
+}
+
+func TestRunFlagsBoundToViper(t *testing.T) {
+	t.Cleanup(func() {
+		_ = runCmd.Flags().Set("http-url", "https://127.0.0.1:8443")
+		_ = runCmd.Flags().Set("debug", "false")
+	})
+
+	for _, name := range []string{"http-url", "debug"} {
+		if runCmd.Flags().Lookup(name) == nil {
+			t.Fatalf("run flag %q is missing", name)
+		}
+	}
+
+	if err := runCmd.Flags().Set("http-url", "https://example.test"); err != nil {
+		t.Fatal(err)
+	}
+	if got := viper.GetString("http-url"); got != "https://example.test" {
+		t.Fatalf("viper http-url = %q", got)
+	}
+
+	if err := runCmd.Flags().Set("debug", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if !viper.GetBool("debug") {
+		t.Fatal("viper debug binding did not observe flag value")
+	}
+}

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -1,19 +1,19 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/dnstapir/edm/pkg/runner"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+var runRunner = runner.Run
 
 // runCmd represents the run command
 var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run dnstapir-edm in dnstap capture mode",
 	Run: func(_ *cobra.Command, _ []string) {
-		runner.Run(edmLogger, edmLoggerLevel)
+		runRunner(edmLogger, edmLoggerLevel)
 	},
 }
 
@@ -77,8 +77,5 @@ func init() {
 	runCmd.Flags().Bool("debug-enable-blockprofiling", false, "Enable profiling of goroutine blocking events")
 	runCmd.Flags().Bool("debug-enable-mutexprofiling", false, "Enable profiling of mutex contention events")
 
-	err := viper.BindPFlags(runCmd.Flags())
-	if err != nil {
-		log.Fatal(err)
-	}
+	cobra.CheckErr(viper.BindPFlags(runCmd.Flags()))
 }

--- a/pkg/protocols/protocols_test.go
+++ b/pkg/protocols/protocols_test.go
@@ -1,0 +1,62 @@
+package protocols
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+func TestBitsFromMsgAllFlags(t *testing.T) {
+	msg := &dns.Msg{
+		MsgHdr: dns.MsgHdr{
+			Response:           true,
+			Opcode:             dns.OpcodeStatus,
+			Authoritative:      true,
+			Truncated:          true,
+			RecursionDesired:   true,
+			RecursionAvailable: true,
+			Zero:               true,
+			AuthenticatedData:  true,
+			CheckingDisabled:   true,
+			Rcode:              dns.RcodeNameError,
+		},
+	}
+
+	got := bitsFromMsg(msg)
+	want := uint16(_QR | (dns.OpcodeStatus << 11) | _AA | _TC | _RD | _RA | _Z | _AD | _CD | dns.RcodeNameError)
+	if got != want {
+		t.Fatalf("bitsFromMsg() = %016b, want %016b", got, want)
+	}
+}
+
+func TestNewQnameEvent(t *testing.T) {
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeAAAA)
+	msg.RecursionDesired = true
+	ts := time.Date(2026, 5, 28, 12, 13, 14, 15, time.UTC)
+
+	got := NewQnameEvent(msg, ts)
+
+	if got.Type != NewQnameJSONType {
+		t.Fatalf("Type = %q, want %q", got.Type, NewQnameJSONType)
+	}
+	if got.Version != NewQnameJSONVersion {
+		t.Fatalf("Version = %d, want %d", got.Version, NewQnameJSONVersion)
+	}
+	if got.Qname != "example.com." {
+		t.Fatalf("Qname = %q", got.Qname)
+	}
+	if got.Qtype == nil || *got.Qtype != int(dns.TypeAAAA) {
+		t.Fatalf("Qtype = %v, want %d", got.Qtype, dns.TypeAAAA)
+	}
+	if got.Qclass == nil || *got.Qclass != int(dns.ClassINET) {
+		t.Fatalf("Qclass = %v, want %d", got.Qclass, dns.ClassINET)
+	}
+	if got.Timestamp == nil || !got.Timestamp.Equal(ts) {
+		t.Fatalf("Timestamp = %v, want %v", got.Timestamp, ts)
+	}
+	if got.Flags == nil || *got.Flags != int(_RD) {
+		t.Fatalf("Flags = %v, want %d", got.Flags, _RD)
+	}
+}

--- a/pkg/runner/aggregate_sender.go
+++ b/pkg/runner/aggregate_sender.go
@@ -132,7 +132,7 @@ func (as aggregateSender) send(fileName string, ts time.Time, duration time.Dura
 	req.Header.Add("Aggregate-Interval", fmt.Sprintf("%s/PT%dM", ts.Truncate(time.Minute).Format(time.RFC3339), minutes))
 
 	as.log.Info("aggregateSender.send", "filename", fileName, "url", histogramURL)
-	startTime := time.Now()
+	startTime := now()
 	res, err := as.signingHTTPClient.Do(req)
 	elapsedTime := time.Since(startTime)
 	if err != nil {

--- a/pkg/runner/mqtt.go
+++ b/pkg/runner/mqtt.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -13,6 +14,12 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jws"
 )
+
+type autoPahoConnection interface {
+	AwaitConnection(context.Context) error
+	Publish(context.Context, *paho.Publish) (*paho.PublishResponse, error)
+	PublishViaQueue(context.Context, *autopaho.QueuePublish) error
+}
 
 const (
 	pahoLogTypeDebug      = "debug"
@@ -88,7 +95,7 @@ func (edm *dnstapMinimiser) newAutoPahoClientConfig(caCertPool *x509.CertPool, s
 	return cliCfg, nil
 }
 
-func (edm *dnstapMinimiser) runAutoPaho(cm *autopaho.ConnectionManager, mqttJWK jwk.Key, usingFileQueue bool) {
+func (edm *dnstapMinimiser) runAutoPaho(cm autoPahoConnection, mqttJWK jwk.Key, usingFileQueue bool) {
 	defer edm.autopahoWg.Done()
 
 	topic := "events/up/" + mqttJWK.KeyID() + "/new_qname"

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -20,7 +20,6 @@ import (
 	"net/netip"
 	"net/url"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -33,7 +32,6 @@ import (
 	"github.com/cockroachdb/pebble"
 	dnstap "github.com/dnstap/golang-dnstap"
 	"github.com/dnstapir/edm/pkg/protocols"
-	"github.com/eclipse/paho.golang/autopaho"
 	"github.com/eclipse/paho.golang/autopaho/queue/file"
 	"github.com/fsnotify/fsnotify"
 	"github.com/go-playground/validator/v10"
@@ -368,7 +366,7 @@ func (edm *dnstapMinimiser) diskCleaner(wg *sync.WaitGroup, sentDir string) {
 	// We will scan the directory each tick for sent files to remove.
 	defer wg.Done()
 
-	ticker := time.NewTicker(time.Second * 60)
+	ticker := time.NewTicker(diskCleanerInterval)
 	defer ticker.Stop()
 
 	oneDay := time.Hour * 12
@@ -607,7 +605,7 @@ func configUpdater(viperNotifyCh chan fsnotify.Event, edm *dnstapMinimiser) {
 		// if more events occur we will reset it again. This allows us
 		// to wait until events on the file settles down before
 		// actually calling the update function.
-		t.Reset(100 * time.Millisecond)
+		t.Reset(configUpdateDebounce)
 	}
 }
 
@@ -660,7 +658,7 @@ func (edm *dnstapMinimiser) setupMQTT() {
 	mqttJWK, err := edDsaJWKFromFile(conf.MQTTSigningKeyFile)
 	if err != nil {
 		edm.log.Error("unable to parse jwk from 'mqtt-signing-key-file'", "error", err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	// Leaving these nil will use the OS default CA certs
@@ -671,7 +669,7 @@ func (edm *dnstapMinimiser) setupMQTT() {
 		mqttCACertPool, err = certPoolFromFile(conf.MQTTCAFile)
 		if err != nil {
 			edm.log.Error("failed to create CA cert pool for '--mqtt-ca-file'", "error", err)
-			os.Exit(1)
+			exitProcess(1)
 		}
 	}
 
@@ -682,13 +680,13 @@ func (edm *dnstapMinimiser) setupMQTT() {
 		err = os.MkdirAll(mqttQueueDir, 0o750)
 		if err != nil {
 			edm.log.Error("unable to create MQTT queue dir", "error", err, "queue_dir", mqttQueueDir)
-			os.Exit(1)
+			exitProcess(1)
 		}
 
-		mqttFileQueue, err = file.New(filepath.Join(conf.DataDir, "mqtt", "queue"), "queue", ".msg")
+		mqttFileQueue, err = newFileQueue(filepath.Join(conf.DataDir, "mqtt", "queue"), "queue", ".msg")
 		if err != nil {
 			edm.log.Error("unable to init MQTT queue file based queue", "error", err)
-			os.Exit(1)
+			exitProcess(1)
 		}
 	}
 
@@ -699,15 +697,15 @@ func (edm *dnstapMinimiser) setupMQTT() {
 	autopahoConfig, err := edm.newAutoPahoClientConfig(mqttCACertPool, conf.MQTTServer, mqttClientID, conf.MQTTKeepalive, mqttFileQueue)
 	if err != nil {
 		edm.log.Error("unable to create autopaho config", "error", err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	edm.autopahoCtx, edm.autopahoCancel = context.WithCancel(context.Background())
 
-	autopahoCm, err := autopaho.NewConnection(edm.autopahoCtx, autopahoConfig)
+	autopahoCm, err := newAutoPahoConnection(edm.autopahoCtx, autopahoConfig)
 	if err != nil {
 		edm.log.Error("unable to create autopaho connection manager", "error", err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	// Connect to the broker - this will return immediately after initiating the connection process
@@ -926,7 +924,7 @@ func (edm *dnstapMinimiser) fsEventWatcher() {
 				timersMutex.Unlock()
 			}
 
-			t.Reset(100 * time.Millisecond)
+			t.Reset(fsEventDebounce)
 		case err, ok := <-edm.fsWatcher.Errors:
 			if !ok {
 				// watcher is closed
@@ -1123,7 +1121,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 	edm, err := newDnstapMinimiser(logger, vc)
 	if err != nil {
 		logger.Error("unable to init", "error", err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 	defer edm.stop()
 	defer edm.fsWatcher.Close()
@@ -1149,13 +1147,13 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 	err = edm.setIgnoredClientIPs()
 	if err != nil {
 		logger.Error("unable to configure ignored client IPs", "error", err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	err = edm.setIgnoredQuestionNames()
 	if err != nil {
 		logger.Error("unable to configure ignored question names", "error", err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	viperNotifyCh := make(chan fsnotify.Event)
@@ -1167,10 +1165,10 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 	})
 
 	pdbDir := filepath.Join(startConf.DataDir, "pebble")
-	pdb, err := pebble.Open(pdbDir, &pebble.Options{})
+	pdb, err := openPebble(pdbDir, &pebble.Options{})
 	if err != nil {
 		logger.Error("unable to open pebble database", "dir", pdbDir, "error", err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 	defer func() {
 		err = pdb.Close()
@@ -1183,13 +1181,13 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 		err := edm.loadHTTPClientCert()
 		if err != nil {
 			edm.log.Error("unable to load x509 HTTP client cert", "error", err)
-			os.Exit(1)
+			exitProcess(1)
 		}
 
 		err = edm.setupHistogramSender()
 		if err != nil {
 			edm.log.Error("unable to setup histogram sender", "error", err)
-			os.Exit(1)
+			exitProcess(1)
 		}
 	}
 
@@ -1197,7 +1195,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 		err := edm.loadMQTTClientCert()
 		if err != nil {
 			edm.log.Error("unable to load x509 mqtt client cert", "error", err)
-			os.Exit(1)
+			exitProcess(1)
 		}
 
 		edm.setupMQTT()
@@ -1206,7 +1204,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 	err = edm.configureFSWatchers(startConf)
 	if err != nil {
 		logger.Error("unable to configure fsWatchers", "error", err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	go edm.fsEventWatcher()
@@ -1215,25 +1213,25 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 	var dti *dnstap.FrameStreamSockInput
 	if startConf.InputUnix != "" {
 		logger.Info("creating dnstap unix socket", "socket", startConf.InputUnix)
-		dti, err = dnstap.NewFrameStreamSockInputFromPath(startConf.InputUnix)
+		dti, err = newFrameStreamSockInputFromPath(startConf.InputUnix)
 		if err != nil {
 			logger.Error("unable to create dnstap unix socket", "error", err)
-			os.Exit(1)
+			exitProcess(1)
 		}
 	} else if startConf.InputTCP != "" {
 		logger.Info("creating plaintext dnstap TCP socket", "socket", startConf.InputTCP)
-		l, err := net.Listen("tcp", startConf.InputTCP)
+		l, err := listenNet("tcp", startConf.InputTCP)
 		if err != nil {
 			logger.Error("unable to create plaintext dnstap TCP socket", "error", err)
-			os.Exit(1)
+			exitProcess(1)
 		}
-		dti = dnstap.NewFrameStreamSockInput(l)
+		dti = newFrameStreamSockInput(l)
 	} else if startConf.InputTLS != "" {
 		logger.Info("creating encrypted dnstap TLS socket", "socket", startConf.InputTLS)
 		dnstapInputCert, err := tls.LoadX509KeyPair(startConf.InputTLSCertFile, startConf.InputTLSKeyFile)
 		if err != nil {
 			logger.Error("unable to load x509 dnstap listener cert", "error", err)
-			os.Exit(1)
+			exitProcess(1)
 		}
 		dnstapTLSConfig := &tls.Config{
 			Certificates: []tls.Certificate{dnstapInputCert},
@@ -1246,19 +1244,19 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 			inputTLSClientCACertPool, err := certPoolFromFile(startConf.InputTLSClientCAFile)
 			if err != nil {
 				logger.Error("failed to create CA cert pool for '-input-tls-client-ca-file': %s", "error", err)
-				os.Exit(1)
+				exitProcess(1)
 			}
 
 			dnstapTLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
 			dnstapTLSConfig.ClientCAs = inputTLSClientCACertPool
 		}
 
-		l, err := tls.Listen("tcp", startConf.InputTLS, dnstapTLSConfig)
+		l, err := listenTLS("tcp", startConf.InputTLS, dnstapTLSConfig)
 		if err != nil {
 			logger.Error("unable to create TCP listener", "error", err)
-			os.Exit(1)
+			exitProcess(1)
 		}
-		dti = dnstap.NewFrameStreamSockInput(l)
+		dti = newFrameStreamSockInput(l)
 	}
 	dti.SetTimeout(time.Second * 5)
 	dti.SetLogger(log.Default())
@@ -1270,7 +1268,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 	seenQnameLRU, err := lru.New[string, struct{}](startConf.QnameSeenEntries)
 	if err != nil {
 		logger.Error("unable to create seen-qname LRU", "error", err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	// Uses the default mux which is modified by importing net/http/pprof
@@ -1281,7 +1279,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 	}
 
 	go func() {
-		err := pprofServer.ListenAndServe()
+		err := listenAndServeHTTP(pprofServer)
 		logger.Error("pprofServer failed", "error", err)
 	}()
 
@@ -1297,7 +1295,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 	// Setup custom promHandler since we want to use our per-edm registry
 	metricsMux.Handle("/metrics", promhttp.InstrumentMetricHandler(edm.promReg, promhttp.HandlerFor(edm.promReg, promhttp.HandlerOpts{Registry: edm.promReg})))
 	go func() {
-		err := metricsServer.ListenAndServe()
+		err := listenAndServeHTTP(metricsServer)
 		logger.Error("metricsServer failed", "error", err)
 	}()
 
@@ -1332,13 +1330,13 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 	dawgFinder, dawgModTime, err := loadDawgFile(dawgFile)
 	if err != nil {
 		edm.log.Error("Run: loadDawgFile failed", "error", err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	wkdTracker, err := newWellKnownDomainsTracker(dawgFinder, dawgModTime)
 	if err != nil {
 		edm.log.Error(err.Error())
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	debugDnstapFilename := startConf.DebugDnstapFilename
@@ -1356,7 +1354,7 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 		debugDnstapFile, err = os.OpenFile(debugDnstapFilename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 		if err != nil {
 			edm.log.Error("unable to open debug dnstap file", "error", err.Error(), "filename", debugDnstapFilename)
-			os.Exit(1)
+			exitProcess(1)
 		}
 		defer func() {
 			err := debugDnstapFile.Close()
@@ -1502,7 +1500,7 @@ func newDnstapMinimiser(logger *slog.Logger, edmConf edmConfiger) (*dnstapMinimi
 	}
 
 	// Exit gracefully on SIGINT or SIGTERM
-	edm.ctx, edm.stop = signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	edm.ctx, edm.stop = notifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 
 	// Use separate prometheus registry for each edm instance, otherwise
 	// trying to run tests where each test do their own call to
@@ -1593,7 +1591,7 @@ func newDnstapMinimiser(logger *slog.Logger, edmConf edmConfiger) (*dnstapMinimi
 	// the histogram sender is currently busy.
 	edm.reloadHistogramSenderConfigCh = make(chan struct{}, 1)
 
-	edm.fsWatcher, err = fsnotify.NewWatcher()
+	edm.fsWatcher, err = newFSWatcher()
 	if err != nil {
 		return nil, fmt.Errorf("newDnstapMinimiser: unable to create fsWatcher: %w", err)
 	}
@@ -2050,7 +2048,7 @@ minimiserLoop:
 func (edm *dnstapMinimiser) monitorChannelLen(wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	ticker := time.NewTicker(time.Second)
+	ticker := time.NewTicker(monitorChannelInterval)
 	defer ticker.Stop()
 
 	edm.log.Info("monitorChannelLen: starting")
@@ -2327,6 +2325,11 @@ func (edm *dnstapMinimiser) renameFile(src string, dst string) error {
 		}
 
 		if errors.Is(err, fs.ErrNotExist) {
+			if _, statErr := os.Stat(dstDir); statErr == nil {
+				return fmt.Errorf("renameFile: unable to rename file, src: %s, dst: %s: %w", src, dst, err)
+			} else if !errors.Is(statErr, fs.ErrNotExist) {
+				return fmt.Errorf("renameFile: unable to stat destination dir: %s: %w", dstDir, statErr)
+			}
 			// If the destination directory does not exist we will
 			// need to create it and then retry the Rename() in the
 			// next iteration of the loop.
@@ -2376,11 +2379,11 @@ func (edm *dnstapMinimiser) createFile(dst string) (*os.File, error) {
 func (edm *dnstapMinimiser) histogramSender(outboxDir string, sentDir string, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	backoffDuration := time.Second * 15
+	backoffDuration := histogramSenderBackoff
 
 	// We will scan the outbox directory each tick for histogram parquet
 	// files to send
-	ticker := time.NewTicker(time.Second * 10)
+	ticker := time.NewTicker(histogramSenderInterval)
 	defer ticker.Stop()
 
 	conf := edm.getConfig()
@@ -2432,7 +2435,7 @@ timerLoop:
 					err = as.send(absPath, startTS, duration)
 					if err != nil {
 						edm.log.Error("histogramSender: unable to send histogram file", "error", err, "backoff_duration", backoffDuration)
-						time.Sleep(backoffDuration)
+						sleep(backoffDuration)
 						continue
 					}
 					err = edm.renameFile(absPath, absPathSent)

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -1,0 +1,1433 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/cockroachdb/pebble"
+	dnstap "github.com/dnstap/golang-dnstap"
+	"github.com/dnstapir/edm/pkg/protocols"
+	"github.com/eclipse/paho.golang/autopaho"
+	"github.com/eclipse/paho.golang/paho"
+	"github.com/fsnotify/fsnotify"
+	"github.com/hashicorp/golang-lru/v2"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/miekg/dns"
+	"github.com/parquet-go/parquet-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/segmentio/go-hll"
+	"github.com/smhanov/dawg"
+	"github.com/spaolacci/murmur3"
+	"github.com/spf13/viper"
+	"go4.org/netipx"
+	"google.golang.org/protobuf/proto"
+)
+
+func writeTempFile(t testing.TB, name string, data []byte) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func testDawgFinder(t testing.TB, domains ...string) dawg.Finder {
+	t.Helper()
+
+	slices.Sort(domains)
+	builder := dawg.New()
+	for _, domain := range domains {
+		builder.Add(domain)
+	}
+	return builder.Finish()
+}
+
+func testDawgFile(t testing.TB, domains ...string) string {
+	t.Helper()
+
+	finder := testDawgFinder(t, domains...)
+	t.Cleanup(func() {
+		if err := finder.Close(); err != nil {
+			t.Fatalf("unable to close test DAWG: %s", err)
+		}
+	})
+
+	path := filepath.Join(t.TempDir(), "domains.dawg")
+	if _, err := finder.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func packedDNSMsg(t testing.TB, name string, qtype uint16, rcode int) []byte {
+	t.Helper()
+
+	msg := new(dns.Msg)
+	msg.SetQuestion(name, qtype)
+	msg.Response = true
+	msg.Rcode = rcode
+	packed, err := msg.Pack()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return packed
+}
+
+func testDnstapMessage(t testing.TB, msgType dnstap.Message_Type, family dnstap.SocketFamily, packed []byte) *dnstap.Dnstap {
+	t.Helper()
+
+	queryPort := uint32(12345)
+	responsePort := uint32(53)
+	querySec := uint64(1_700_000_000)
+	queryNSec := uint32(123)
+	responseSec := uint64(1_700_000_001)
+	responseNSec := uint32(456)
+	protoUDP := dnstap.SocketProtocol_UDP
+	topType := dnstap.Dnstap_MESSAGE
+	dt := &dnstap.Dnstap{
+		Type:     &topType,
+		Identity: []byte("server-1"),
+		Message: &dnstap.Message{
+			Type:             &msgType,
+			SocketFamily:     &family,
+			SocketProtocol:   &protoUDP,
+			QueryPort:        &queryPort,
+			ResponsePort:     &responsePort,
+			QueryTimeSec:     &querySec,
+			QueryTimeNsec:    &queryNSec,
+			ResponseTimeSec:  &responseSec,
+			ResponseTimeNsec: &responseNSec,
+		},
+	}
+
+	switch family {
+	case dnstap.SocketFamily_INET:
+		dt.Message.QueryAddress = netip.MustParseAddr("198.51.100.20").AsSlice()
+		dt.Message.ResponseAddress = netip.MustParseAddr("198.51.100.53").AsSlice()
+	case dnstap.SocketFamily_INET6:
+		dt.Message.QueryAddress = netip.MustParseAddr("2001:db8::20").AsSlice()
+		dt.Message.ResponseAddress = netip.MustParseAddr("2001:db8::53").AsSlice()
+	}
+
+	if strings.HasSuffix(dnstap.Message_Type_name[int32(msgType)], "_QUERY") {
+		dt.Message.QueryMessage = packed
+	} else {
+		dt.Message.ResponseMessage = packed
+	}
+	return dt
+}
+
+func marshaledDnstap(t testing.TB, dt *dnstap.Dnstap) []byte {
+	t.Helper()
+
+	data, err := proto.Marshal(dt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func testJWK(t testing.TB) jwk.Key {
+	t.Helper()
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := jwk.FromRaw(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := key.Set(jwk.KeyIDKey, "test-key"); err != nil {
+		t.Fatal(err)
+	}
+	if err := key.Set(jwk.AlgorithmKey, jwa.EdDSA); err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+func testJWKFile(t testing.TB) string {
+	t.Helper()
+
+	data, err := json.Marshal(testJWK(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return writeTempFile(t, "key.jwk", data)
+}
+
+func testCertFiles(t testing.TB) (string, string, string) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		IsCA:         true,
+		DNSNames:     []string{"localhost"},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+	caPath := filepath.Join(dir, "ca.pem")
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caPath, certPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return certPath, keyPath, caPath
+}
+
+func newTestPebble(t testing.TB) *pebble.DB {
+	t.Helper()
+
+	db, err := pebble.Open(filepath.Join(t.TempDir(), "pebble"), &pebble.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("unable to close pebble: %s", err)
+		}
+	})
+	return db
+}
+
+func TestCertStore(t *testing.T) {
+	store := newCertStore()
+	if _, err := store.getClientCertificate(nil); !errors.Is(err, errNoClientCertificate) {
+		t.Fatalf("empty getClientCertificate error = %v", err)
+	}
+
+	certPath, keyPath, _ := testCertFiles(t)
+	if err := store.loadCert(certPath, keyPath); err != nil {
+		t.Fatal(err)
+	}
+	cert, err := store.getClientCertificate(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cert.Certificate) == 0 {
+		t.Fatal("loaded certificate is empty")
+	}
+
+	if err := store.loadCert(certPath, keyPath+".missing"); err == nil {
+		t.Fatal("loadCert with missing key succeeded")
+	}
+}
+
+func TestSetLabelsNilAndBoundedReverse(t *testing.T) {
+	edm := &dnstapMinimiser{}
+
+	labels := edm.reverseLabelsBounded(nil, 10)
+	if labels != nil {
+		t.Fatalf("nil labels = %#v", labels)
+	}
+
+	dl := &dnsLabels{}
+	edm.setLabels(nil, 10, dl)
+	if dl.Label0 != nil {
+		t.Fatalf("nil labels set Label0 = %q", *dl.Label0)
+	}
+
+	got := edm.reverseLabelsBounded([]string{"a", "b", "c"}, 10)
+	want := []string{"c", "b", "a"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("reverseLabelsBounded = %#v, want %#v", got, want)
+	}
+}
+
+func TestSetCryptopanInvalidCacheSize(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	if err := edm.setCryptopan("key", "salt", -1); err == nil {
+		t.Fatal("setCryptopan accepted negative cache size")
+	}
+}
+
+func TestCertPoolAndJWKFiles(t *testing.T) {
+	_, _, caPath := testCertFiles(t)
+	pool, err := certPoolFromFile(caPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pool.Subjects()) == 0 {
+		t.Fatal("cert pool has no subjects")
+	}
+
+	if _, err := certPoolFromFile(writeTempFile(t, "bad-ca.pem", []byte("not pem"))); err == nil {
+		t.Fatal("bad CA file succeeded")
+	}
+	if _, err := certPoolFromFile(filepath.Join(t.TempDir(), "missing.pem")); err == nil {
+		t.Fatal("missing CA file succeeded")
+	}
+
+	keyPath := testJWKFile(t)
+	key, err := edDsaJWKFromFile(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key.Algorithm() != jwa.EdDSA {
+		t.Fatalf("algorithm = %v", key.Algorithm())
+	}
+	if _, err := edDsaJWKFromFile(writeTempFile(t, "bad.jwk", []byte("{"))); err == nil {
+		t.Fatal("bad JWK succeeded")
+	}
+	if _, err := edDsaJWKFromFile(filepath.Join(t.TempDir(), "missing.jwk")); err == nil {
+		t.Fatal("missing JWK succeeded")
+	}
+}
+
+func TestLoadDawgFileErrors(t *testing.T) {
+	if _, _, err := loadDawgFile(filepath.Join(t.TempDir(), "missing.dawg")); err == nil {
+		t.Fatal("missing DAWG succeeded")
+	}
+	if _, _, err := loadDawgFile(writeTempFile(t, "empty.dawg", nil)); !errors.Is(err, errEmptyDawgFile) {
+		t.Fatalf("empty DAWG error = %v", err)
+	}
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("invalid DAWG did not panic")
+			}
+		}()
+		_, _, _ = loadDawgFile(writeTempFile(t, "invalid.dawg", []byte("bad")))
+	}()
+
+	finder, _, err := loadDawgFile(testDawgFile(t, "example.com."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := finder.Close(); err != nil {
+			t.Fatalf("close loaded DAWG: %s", err)
+		}
+	})
+	if finder.NumAdded() != 1 {
+		t.Fatalf("NumAdded = %d", finder.NumAdded())
+	}
+}
+
+func TestIgnoredFileErrors(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+
+	edm.conf.IgnoredClientIPsFile = filepath.Join(t.TempDir(), "missing")
+	if err := edm.setIgnoredClientIPs(); err == nil {
+		t.Fatal("missing ignored-client file succeeded")
+	}
+
+	edm.conf.IgnoredClientIPsFile = writeTempFile(t, "bad-cidr", []byte("not-a-prefix\n"))
+	if err := edm.setIgnoredClientIPs(); err == nil {
+		t.Fatal("bad CIDR succeeded")
+	}
+
+	edm.conf.IgnoredQuestionNamesFile = filepath.Join(t.TempDir(), "missing.dawg")
+	if err := edm.setIgnoredQuestionNames(); err == nil {
+		t.Fatal("missing ignored-question file succeeded")
+	}
+}
+
+func TestFileAndFilenameHelpers(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	base := t.TempDir()
+	start := time.Date(2026, 5, 28, 12, 0, 0, 0, time.FixedZone("test", 2*60*60))
+	stop := start.Add(time.Minute)
+
+	tmpName, finalName := buildParquetFilenames(base, "dns_histogram", start, stop)
+	if !strings.HasSuffix(tmpName, ".parquet.tmp") || !strings.HasSuffix(finalName, ".parquet") {
+		t.Fatalf("unexpected filenames: %q %q", tmpName, finalName)
+	}
+	if timestampToFileString(start.UTC()) != "2026-05-28T10-00-00Z" {
+		t.Fatalf("unexpected timestamp string: %s", timestampToFileString(start.UTC()))
+	}
+	if got := getStartTimeFromRotationTime(stop); !got.Equal(start) {
+		t.Fatalf("start time = %v, want %v", got, start)
+	}
+
+	parsedStart, parsedStop, err := timestampsFromFilename(filepath.Base(finalName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !parsedStart.Equal(start.UTC()) || !parsedStop.Equal(stop.UTC()) {
+		t.Fatalf("parsed times = %v %v", parsedStart, parsedStop)
+	}
+	if _, _, err := timestampsFromFilename("dns_histogram-bad_bad.parquet"); err == nil {
+		t.Fatal("bad timestamp filename succeeded")
+	}
+	if _, _, err := timestampsFromFilename("dns_histogram-2026-05-28T10-00-00Z_bad.parquet"); err == nil {
+		t.Fatal("bad stop timestamp filename succeeded")
+	}
+
+	out, err := edm.createFile(filepath.Join(base, "missing", "created.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := edm.renameFile(out.Name(), filepath.Join(base, "sent", "created.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := edm.createFile(base); err == nil {
+		t.Fatal("createFile on directory succeeded")
+	}
+	if err := edm.renameFile(filepath.Join(base, "nope"), filepath.Join(base, "dst")); err == nil {
+		t.Fatal("rename missing source succeeded")
+	}
+}
+
+func TestIPConversionErrorsAndPseudonymiseInvalid(t *testing.T) {
+	if _, err := ipBytesToInt([]byte{1, 2, 3}); err == nil {
+		t.Fatal("short IPv4 bytes succeeded")
+	}
+	if _, _, err := ip6BytesToInt([]byte{1, 2, 3}); err == nil {
+		t.Fatal("short IPv6 bytes succeeded")
+	}
+
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	got, err := edm.pseudonymiseIP([]byte{1, 2, 3})
+	if err == nil {
+		t.Fatal("invalid pseudonymiseIP succeeded")
+	}
+	if !bytes.Equal(got, []byte{0, 0, 0}) {
+		t.Fatalf("invalid pseudonymiseIP returned %v", got)
+	}
+
+	dt := &dnstap.Dnstap{Message: &dnstap.Message{QueryAddress: []byte{1, 2, 3}, ResponseAddress: []byte{4, 5, 6}}}
+	edm.pseudonymiseDnstap(dt)
+	if !bytes.Equal(dt.Message.QueryAddress, []byte{0, 0, 0}) || !bytes.Equal(dt.Message.ResponseAddress, []byte{0, 0, 0}) {
+		t.Fatalf("invalid dnstap addresses were not zeroed: %#v", dt.Message)
+	}
+}
+
+func TestParseHLLStorageTypeErrors(t *testing.T) {
+	if _, err := parseHllStorageType(nil); err == nil {
+		t.Fatal("empty HLL bytes succeeded")
+	}
+	if _, err := parseHllStorageType([]byte{0x20}); err == nil {
+		t.Fatal("unsupported HLL version succeeded")
+	}
+
+	h, err := hll.NewHll(getHllDefaults(10))
+	if err != nil {
+		t.Fatal(err)
+	}
+	storageType, err := parseHllStorageType(h.ToBytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if storageType != hllEmpty {
+		t.Fatalf("storage type = %v, want hllEmpty", storageType)
+	}
+}
+
+func TestNewHistogramDataAndWriteParquet(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+
+	exact := edm.newHistogramData(getHllDefaults(0), false)
+	if exact.EDMStatusBits != uint64(edmStatusWellKnownExact) {
+		t.Fatalf("exact status = %d", exact.EDMStatusBits)
+	}
+	wildcard := edm.newHistogramData(getHllDefaults(0), true)
+	if wildcard.EDMStatusBits != uint64(edmStatusWellKnownWildcard) {
+		t.Fatalf("wildcard status = %d", wildcard.EDMStatusBits)
+	}
+
+	finder := testDawgFinder(t, "example.com.")
+	wkd := &wellKnownDomainsData{
+		m:          map[int]*histogramData{0: exact},
+		dawgFinder: finder,
+	}
+	exact.ACount = 1
+	exact.v4ClientHLL.AddRaw(murmur3.Sum64(netip.MustParseAddr("198.51.100.20").AsSlice()))
+
+	var buf bytes.Buffer
+	if err := edm.writeHistogramParquet(&buf, time.Unix(10, 0), wkd, defaultLabelLimit); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := parquet.Read[histogramData](bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].ACount != 1 || rows[0].V4ClientCount == 0 {
+		t.Fatalf("unexpected rows: %#v", rows)
+	}
+
+	badWKD := &wellKnownDomainsData{m: map[int]*histogramData{99: exact}, dawgFinder: finder}
+	if err := edm.writeHistogramParquet(io.Discard, time.Time{}, badWKD, defaultLabelLimit); err == nil {
+		t.Fatal("writeHistogramParquet with bad DAWG index succeeded")
+	}
+}
+
+func TestSessionParquetAndSessionConstruction(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	packed := packedDNSMsg(t, "www.example.com.", dns.TypeA, dns.RcodeSuccess)
+	dt := testDnstapMessage(t, dnstap.Message_CLIENT_RESPONSE, dnstap.SocketFamily_INET, packed)
+	msg, ts := edm.parsePacket(dt, false)
+	if msg == nil {
+		t.Fatal("parsePacket returned nil msg")
+	}
+	if !ts.Equal(time.Unix(1_700_000_001, 456).UTC()) {
+		t.Fatalf("response timestamp = %v", ts)
+	}
+	sd := edm.newSession(dt, msg, false, defaultLabelLimit, ts)
+	if sd.ResponseTime == nil || sd.ResponseMessage == nil || sd.ServerID == nil {
+		t.Fatalf("session missing response fields: %#v", sd)
+	}
+	if sd.SourceIPv4 == nil || sd.DestIPv4 == nil || sd.DNSProtocol == nil {
+		t.Fatalf("session missing network fields: %#v", sd)
+	}
+
+	var buf bytes.Buffer
+	if err := edm.writeSessionParquet(&buf, &prevSessions{sessions: []*sessionData{sd}}); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := parquet.Read[sessionData](bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].ServerID == nil || *rows[0].ServerID != "server-1" {
+		t.Fatalf("unexpected session rows: %#v", rows)
+	}
+
+	queryDT := testDnstapMessage(t, dnstap.Message_CLIENT_QUERY, dnstap.SocketFamily_INET6, packed)
+	queryMsg, queryTS := edm.parsePacket(queryDT, true)
+	querySession := edm.newSession(queryDT, queryMsg, true, defaultLabelLimit, queryTS)
+	if querySession.QueryTime == nil || querySession.QueryMessage == nil || querySession.SourceIPv6Network == nil || querySession.DestIPv6Host == nil {
+		t.Fatalf("query session missing fields: %#v", querySession)
+	}
+
+	huge := uint64(math.MaxInt64) + 1
+	queryDT.Message.QueryTimeSec = &huge
+	if _, zeroTS := edm.parsePacket(queryDT, true); !zeroTS.Equal(time.Unix(0, 0).UTC()) {
+		t.Fatalf("overflow query timestamp = %v, want Unix zero", zeroTS)
+	}
+	responseDT := testDnstapMessage(t, dnstap.Message_CLIENT_RESPONSE, dnstap.SocketFamily_INET, packed)
+	huge = uint64(math.MaxInt64) + 1
+	responseDT.Message.ResponseTimeSec = &huge
+	if _, zeroTS := edm.parsePacket(responseDT, false); !zeroTS.Equal(time.Unix(0, 0).UTC()) {
+		t.Fatalf("overflow response timestamp = %v, want Unix zero", zeroTS)
+	}
+
+	badMsg, _ := edm.parsePacket(&dnstap.Dnstap{Message: &dnstap.Message{QueryMessage: []byte{1}, QueryTimeSec: ptr(uint64(0)), QueryTimeNsec: ptr(uint32(0))}}, true)
+	if badMsg != nil {
+		t.Fatal("bad query packet returned non-nil message")
+	}
+}
+
+func TestCreateSessionAndHistogramFiles(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	dataDir := t.TempDir()
+	rotationTime := time.Date(2026, 5, 28, 12, 1, 0, 0, time.UTC)
+	ps := &prevSessions{
+		rotationTime: rotationTime,
+		sessions: []*sessionData{{
+			dnsLabels: dnsLabels{Label0: ptr("com")},
+			ServerID:  ptr("server"),
+		}},
+	}
+	sessionFile, err := edm.createSessionFile(ps, dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.HasSuffix(sessionFile, ".tmp") {
+		t.Fatalf("session file kept tmp suffix: %s", sessionFile)
+	}
+
+	finder := testDawgFinder(t, "example.com.")
+	hd := edm.newHistogramData(getHllDefaults(0), false)
+	wkd := &wellKnownDomainsData{rotationTime: rotationTime, dawgFinder: finder, m: map[int]*histogramData{0: hd}}
+	histFile, err := edm.createHistogramFile(wkd, defaultLabelLimit, filepath.Join(dataDir, "parquet", "histograms", "outbox"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.HasSuffix(histFile, ".tmp") {
+		t.Fatalf("histogram file kept tmp suffix: %s", histFile)
+	}
+}
+
+func TestQnameSeen(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	db := newTestPebble(t)
+	cache, err := lru.New[string, struct{}](1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("Example.COM.", dns.TypeA)
+	if edm.qnameSeen(msg, cache, db) {
+		t.Fatal("first qnameSeen call returned true")
+	}
+	if !edm.qnameSeen(msg, cache, db) {
+		t.Fatal("second qnameSeen call returned false")
+	}
+
+	cache, err = lru.New[string, struct{}](1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !edm.qnameSeen(msg, cache, db) {
+		t.Fatal("qnameSeen did not find qname in pebble")
+	}
+
+	other := new(dns.Msg)
+	other.SetQuestion("other.example.", dns.TypeA)
+	_ = edm.qnameSeen(other, cache, db)
+}
+
+func TestWellKnownDomainUpdatesAndRotation(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	path := testDawgFile(t, "example.com.")
+	finder, modTime, err := loadDawgFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = finder.Close() })
+
+	wkd, err := newWellKnownDomainsTracker(finder, modTime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeMX)
+	msg.Rcode = dns.RcodeNameError
+	wkd.sendUpdate(netip.MustParseAddr("198.51.100.20").AsSlice(), msg, 0, false, modTime)
+
+	select {
+	case wu := <-wkd.updateCh:
+		if wu.NXCount != 1 || wu.MXCount != 1 || !wu.ip.IsValid() || wu.hllHash == 0 {
+			t.Fatalf("unexpected update: %#v", wu)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for update")
+	}
+
+	prev, err := wkd.rotateTracker(edm, path, time.Unix(60, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !prev.rotationTime.Equal(time.Unix(60, 0)) || len(wkd.m) != 0 {
+		t.Fatalf("unexpected rotation state: %#v", prev)
+	}
+
+	if _, err := wkd.rotateTracker(edm, filepath.Join(t.TempDir(), "missing.dawg"), time.Now()); err == nil {
+		t.Fatal("rotateTracker with missing file succeeded")
+	}
+}
+
+func TestUpdateRetryer(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	finder := testDawgFinder(t, "example.com.")
+	wkd, err := newWellKnownDomainsTracker(finder, time.Unix(2, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeA)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go wkd.updateRetryer(edm, &wg)
+	wkd.retryCh <- wkdUpdate{msg: msg, dawgModTime: time.Unix(1, 0), retryLimit: 2}
+	close(wkd.retryCh)
+
+	select {
+	case wu := <-wkd.updateCh:
+		if wu.retry != 1 || wu.dawgIndex != 0 || wu.dawgModTime != time.Unix(2, 0) {
+			t.Fatalf("unexpected retried update: %#v", wu)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for retried update")
+	}
+	wg.Wait()
+	<-wkd.retryerDone
+}
+
+func TestFSWatchersAndEventWatcher(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	dir := t.TempDir()
+	watched := filepath.Join(dir, "watched.txt")
+	var calls atomic.Int32
+	edm.fsWatcherFuncs = map[string][]func() error{
+		watched: {
+			func() error {
+				calls.Add(1)
+				return errors.New("logged")
+			},
+		},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		edm.fsEventWatcher()
+	}()
+	edm.fsWatcher.Events <- fsnotifyEvent(watched)
+	time.Sleep(150 * time.Millisecond)
+	if calls.Load() != 1 {
+		t.Fatalf("watcher callbacks = %d, want 1", calls.Load())
+	}
+	if err := edm.fsWatcher.Close(); err != nil {
+		t.Fatal(err)
+	}
+	wg.Wait()
+}
+
+func fsnotifyEvent(name string) fsnotify.Event {
+	return fsnotify.Event{Name: name, Op: fsnotify.Write}
+}
+
+func TestConfigureFSWatchers(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	dir := t.TempDir()
+	edm.conf.IgnoredClientIPsFile = filepath.Join(dir, "ignored-ips")
+	edm.conf.IgnoredQuestionNamesFile = filepath.Join(dir, "ignored-names")
+	edm.conf.HTTPClientCertFile = filepath.Join(dir, "http-cert")
+	edm.conf.MQTTClientCertFile = filepath.Join(dir, "mqtt-cert")
+	edm.conf.DisableHistogramSender = false
+	startConf := edm.conf
+	startConf.DisableMQTT = false
+
+	if err := edm.configureFSWatchers(startConf); err != nil {
+		t.Fatal(err)
+	}
+	if len(edm.fsWatcherFuncs) != 4 {
+		t.Fatalf("fsWatcherFuncs = %d, want 4", len(edm.fsWatcherFuncs))
+	}
+
+	edm.conf.IgnoredClientIPsFile = ""
+	edm.conf.IgnoredQuestionNamesFile = ""
+	edm.conf.HTTPClientCertFile = ""
+	edm.conf.MQTTClientCertFile = ""
+	if err := edm.configureFSWatchers(startConf); err != nil {
+		t.Fatal(err)
+	}
+	if len(edm.fsWatcherFuncs) != 0 {
+		t.Fatalf("fsWatcherFuncs after cleanup = %d", len(edm.fsWatcherFuncs))
+	}
+}
+
+func TestAggregateSender(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	payload := []byte("parquet-ish")
+	fileName := writeTempFile(t, "hist.parquet", payload)
+
+	var sawRequest bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawRequest = true
+		if r.URL.Path != "/api/v1/aggregate/histogram" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/vnd.apache.parquet" {
+			t.Fatalf("content type = %q", r.Header.Get("Content-Type"))
+		}
+		if r.Header.Get("Aggregate-Interval") != "2026-05-28T12:34:00Z/PT2M" {
+			t.Fatalf("aggregate interval = %q", r.Header.Get("Aggregate-Interval"))
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(body, payload) {
+			t.Fatalf("body = %q", body)
+		}
+		w.Header().Set("Location", "/uploaded/hist.parquet")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(server.Close)
+
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	as, err := edm.newAggregateSender(u, testJWK(t), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := as.send(fileName, time.Date(2026, 5, 28, 12, 34, 56, 0, time.UTC), 2*time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	if !sawRequest {
+		t.Fatal("server did not receive request")
+	}
+
+	if err := as.send(filepath.Join(t.TempDir(), "missing.parquet"), time.Now(), time.Minute); err == nil {
+		t.Fatal("sending missing file succeeded")
+	}
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	badKey, err := jwk.FromRaw(rsaKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := edm.newAggregateSender(u, badKey, nil); err == nil {
+		t.Fatal("newAggregateSender accepted non-Ed25519 key")
+	}
+}
+
+func TestAggregateSenderStatusAndLocationErrors(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	fileName := writeTempFile(t, "hist.parquet", []byte("data"))
+
+	statusServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusBadRequest)
+	}))
+	t.Cleanup(statusServer.Close)
+	statusURL, err := url.Parse(statusServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	as, err := edm.newAggregateSender(statusURL, testJWK(t), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := as.send(fileName, time.Now(), time.Minute); err == nil {
+		t.Fatal("unexpected status succeeded")
+	}
+
+	locationServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", ":// bad")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(locationServer.Close)
+	locationURL, err := url.Parse(locationServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	as.aggrecURL = locationURL
+	if err := as.send(fileName, time.Now(), time.Minute); err == nil {
+		t.Fatal("bad Location succeeded")
+	}
+}
+
+func TestHistogramSender(t *testing.T) {
+	oldInterval := histogramSenderInterval
+	oldBackoff := histogramSenderBackoff
+	t.Cleanup(func() {
+		histogramSenderInterval = oldInterval
+		histogramSenderBackoff = oldBackoff
+	})
+	histogramSenderInterval = time.Millisecond
+	histogramSenderBackoff = time.Millisecond
+
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	edm.reloadHistogramSenderConfigCh = make(chan struct{}, 1)
+	outboxDir := filepath.Join(t.TempDir(), "outbox")
+	sentDir := filepath.Join(t.TempDir(), "sent")
+	if err := os.MkdirAll(outboxDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	name := "dns_histogram-2026-05-28T12-00-00Z_2026-05-28T12-01-00Z.parquet"
+	if err := os.WriteFile(filepath.Join(outboxDir, name), []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "/ok")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(server.Close)
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	as, err := edm.newAggregateSender(u, testJWK(t), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	edm.aggregSender = as
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go edm.histogramSender(outboxDir, sentDir, &wg)
+	for range 200 {
+		if _, err := os.Stat(filepath.Join(sentDir, name)); err == nil {
+			edm.stop()
+			wg.Wait()
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	edm.stop()
+	wg.Wait()
+	t.Fatal("histogramSender did not move sent file")
+}
+
+func TestMQTTConfigAndPublisher(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	edm.autopahoCtx, edm.autopahoCancel = context.WithCancel(t.Context())
+	t.Cleanup(edm.autopahoCancel)
+
+	cfg, err := edm.newAutoPahoClientConfig(nil, "mqtts://example.test:8883", "client-id", 30, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ClientConfig.ClientID != "client-id" || cfg.KeepAlive != 30 || cfg.TlsCfg.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("unexpected MQTT config: %#v", cfg)
+	}
+	cfg.OnConnectionUp(nil, nil)
+	cfg.OnConnectError(errors.New("connect"))
+	cfg.ClientConfig.OnClientError(errors.New("client"))
+	cfg.ClientConfig.OnServerDisconnect(&paho.Disconnect{ReasonCode: 1})
+	cfg.ClientConfig.OnServerDisconnect(&paho.Disconnect{Properties: &paho.DisconnectProperties{ReasonString: "bye"}})
+	if _, err := edm.newAutoPahoClientConfig(nil, "://bad", "client-id", 30, nil); err == nil {
+		t.Fatal("bad MQTT URL succeeded")
+	}
+
+	jwk := testJWK(t)
+	conn := &fakeAutoPahoConnection{}
+	edm.autopahoWg.Add(1)
+	go edm.runAutoPaho(conn, jwk, true)
+	edm.mqttPubCh <- []byte(`{"hello":"world"}`)
+	close(edm.mqttPubCh)
+	edm.autopahoWg.Wait()
+	conn.mu.Lock()
+	queued := len(conn.queued)
+	conn.mu.Unlock()
+	if queued != 1 {
+		t.Fatalf("queued messages = %d, want 1", queued)
+	}
+
+	var buf bytes.Buffer
+	pahoDebugLogger{logger: slog.New(slog.NewTextHandler(&buf, nil))}.Printf("hello %s", "debug")
+	pahoDebugLogger{logger: slog.New(slog.NewTextHandler(&buf, nil))}.Println("hello", "debug")
+	pahoErrorLogger{logger: slog.New(slog.NewTextHandler(&buf, nil))}.Printf("hello %s", "error")
+	pahoErrorLogger{logger: slog.New(slog.NewTextHandler(&buf, nil))}.Println("hello", "error")
+	if !strings.Contains(buf.String(), "hello") {
+		t.Fatalf("logger output = %q", buf.String())
+	}
+}
+
+func TestRunAutoPahoPublishPath(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	edm.autopahoCtx, edm.autopahoCancel = context.WithCancel(t.Context())
+	t.Cleanup(edm.autopahoCancel)
+	jwk := testJWK(t)
+	conn := &fakeAutoPahoConnection{}
+
+	edm.autopahoWg.Add(1)
+	go edm.runAutoPaho(conn, jwk, false)
+	edm.mqttPubCh <- []byte(`{"publish":"now"}`)
+	time.Sleep(20 * time.Millisecond)
+	close(edm.mqttPubCh)
+	edm.autopahoWg.Wait()
+	time.Sleep(20 * time.Millisecond)
+
+	conn.mu.Lock()
+	published := len(conn.published)
+	conn.mu.Unlock()
+	if published != 1 {
+		t.Fatalf("published messages = %d, want 1", published)
+	}
+}
+
+func TestRunAutoPahoAwaitError(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	edm.autopahoCtx, edm.autopahoCancel = context.WithCancel(t.Context())
+	t.Cleanup(edm.autopahoCancel)
+	conn := &fakeAutoPahoConnection{awaitErr: context.Canceled}
+
+	edm.autopahoWg.Add(1)
+	go edm.runAutoPaho(conn, testJWK(t), false)
+	edm.autopahoWg.Wait()
+}
+
+type fakeAutoPahoConnection struct {
+	mu        sync.Mutex
+	queued    []*autopaho.QueuePublish
+	published []*paho.Publish
+	awaitErr  error
+}
+
+func (f *fakeAutoPahoConnection) AwaitConnection(context.Context) error {
+	return f.awaitErr
+}
+
+func (f *fakeAutoPahoConnection) Publish(_ context.Context, p *paho.Publish) (*paho.PublishResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.published = append(f.published, p)
+	return &paho.PublishResponse{}, nil
+}
+
+func (f *fakeAutoPahoConnection) PublishViaQueue(_ context.Context, p *autopaho.QueuePublish) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.queued = append(f.queued, p)
+	return nil
+}
+
+func TestNewQnamePublisher(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	edm.autopahoCtx, edm.autopahoCancel = context.WithCancel(t.Context())
+	edm.newQnamePublisherCh = make(chan *protocols.NewQnameJSON, 1)
+	edm.mqttPubCh = make(chan []byte, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go edm.newQnamePublisher(&wg)
+	event := protocols.NewQnameJSON{Type: protocols.NewQnameJSONType, Qname: "example.com.", Version: protocols.NewQnameJSONVersion}
+	edm.newQnamePublisherCh <- &event
+	close(edm.newQnamePublisherCh)
+	wg.Wait()
+
+	msg := <-edm.mqttPubCh
+	if !strings.Contains(string(msg), "example.com.") {
+		t.Fatalf("MQTT payload = %s", msg)
+	}
+	if _, ok := <-edm.mqttPubCh; ok {
+		t.Fatal("mqttPubCh was not closed")
+	}
+}
+
+func TestSetupHistogramSenderAndCertLoaders(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	certPath, keyPath, caPath := testCertFiles(t)
+	httpKeyPath := testJWKFile(t)
+	mqttKeyPath := testJWKFile(t)
+
+	edm.conf.HTTPURL = "https://example.test"
+	edm.conf.HTTPSigningKeyFile = httpKeyPath
+	edm.conf.HTTPCAFile = caPath
+	edm.conf.HTTPClientCertFile = certPath
+	edm.conf.HTTPClientKeyFile = keyPath
+	edm.conf.MQTTClientCertFile = certPath
+	edm.conf.MQTTClientKeyFile = keyPath
+	if err := edm.loadHTTPClientCert(); err != nil {
+		t.Fatal(err)
+	}
+	if err := edm.loadMQTTClientCert(); err != nil {
+		t.Fatal(err)
+	}
+	if err := edm.setupHistogramSender(); err != nil {
+		t.Fatal(err)
+	}
+	if edm.aggregSender.aggrecURL.String() != "https://example.test" {
+		t.Fatalf("aggregate URL = %s", edm.aggregSender.aggrecURL)
+	}
+
+	edm.conf.HTTPURL = "://bad"
+	if err := edm.setupHistogramSender(); err == nil {
+		t.Fatal("bad HTTP URL succeeded")
+	}
+	edm.conf.HTTPURL = "https://example.test"
+	edm.conf.HTTPSigningKeyFile = filepath.Join(t.TempDir(), "missing.jwk")
+	if err := edm.setupHistogramSender(); err == nil {
+		t.Fatal("missing HTTP signing key succeeded")
+	}
+
+	edm.conf.MQTTSigningKeyFile = mqttKeyPath
+}
+
+func TestSetupMQTT(t *testing.T) {
+	oldNewAutoPahoConnection := newAutoPahoConnection
+	oldExitProcess := exitProcess
+	t.Cleanup(func() {
+		newAutoPahoConnection = oldNewAutoPahoConnection
+		exitProcess = oldExitProcess
+	})
+
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	edm.conf.DataDir = t.TempDir()
+	edm.conf.MQTTSigningKeyFile = testJWKFile(t)
+	edm.conf.MQTTServer = "mqtts://example.test:8883"
+	edm.conf.MQTTKeepalive = 30
+	edm.conf.DisableMQTTFilequeue = false
+	newAutoPahoConnection = func(context.Context, autopaho.ClientConfig) (*autopaho.ConnectionManager, error) {
+		return nil, nil
+	}
+
+	edm.setupMQTT()
+	close(edm.mqttPubCh)
+	edm.autopahoWg.Wait()
+	if edm.autopahoCancel == nil {
+		t.Fatal("autopaho cancel was not set")
+	}
+
+	exitProcess = func(int) { panic("exit") }
+	edm.conf.MQTTSigningKeyFile = filepath.Join(t.TempDir(), "missing.jwk")
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("setupMQTT did not exit on missing key")
+			}
+		}()
+		edm.setupMQTT()
+	}()
+}
+
+type sequenceConfiger struct {
+	configs []config
+	index   int
+	err     error
+}
+
+func (sc *sequenceConfiger) getConfig() (config, error) {
+	if sc.err != nil {
+		return config{}, sc.err
+	}
+	if sc.index >= len(sc.configs) {
+		return sc.configs[len(sc.configs)-1], nil
+	}
+	conf := sc.configs[sc.index]
+	sc.index++
+	return conf, nil
+}
+
+func TestConfigUpdater(t *testing.T) {
+	oldDebounce := configUpdateDebounce
+	t.Cleanup(func() {
+		configUpdateDebounce = oldDebounce
+	})
+	configUpdateDebounce = 10 * time.Millisecond
+
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	startConf := edm.getConfig()
+	nextConf := startConf
+	nextConf.CryptopanKey = "key2"
+	nextConf.DisableHistogramSender = true
+	nextConf.IgnoredClientIPsFile = ""
+	nextConf.IgnoredQuestionNamesFile = ""
+	sc := &sequenceConfiger{configs: []config{nextConf}}
+	edm.configer = sc
+	edm.reloadMinimiserConfigCh = []chan struct{}{make(chan struct{}, 1)}
+	edm.reloadHistogramSenderConfigCh = make(chan struct{}, 1)
+
+	events := make(chan fsnotify.Event)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		configUpdater(events, edm)
+	}()
+	events <- fsnotify.Event{Name: "config.toml", Op: fsnotify.Write}
+	for range 100 {
+		if edm.getConfig().CryptopanKey == "key2" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if edm.getConfig().CryptopanKey != "key2" {
+		t.Fatalf("config was not updated: %#v", edm.getConfig())
+	}
+	select {
+	case <-edm.reloadMinimiserConfigCh[0]:
+	case <-time.After(time.Second):
+		t.Fatal("minimiser reload notification not queued")
+	}
+	select {
+	case <-edm.reloadHistogramSenderConfigCh:
+	case <-time.After(time.Second):
+		t.Fatal("histogram reload notification not queued")
+	}
+	close(events)
+	<-done
+}
+
+func TestMonitorAndDiskCleaner(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		edm := &dnstapMinimiser{
+			ctx:                    ctx,
+			stop:                   cancel,
+			log:                    slog.New(slog.NewTextHandler(io.Discard, nil)),
+			promNewQnameChannelLen: prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_gauge"}),
+			newQnamePublisherCh:    make(chan *protocols.NewQnameJSON, 3),
+		}
+		edm.newQnamePublisherCh = make(chan *protocols.NewQnameJSON, 3)
+		edm.newQnamePublisherCh <- &protocols.NewQnameJSON{}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go edm.monitorChannelLen(&wg)
+		time.Sleep(time.Second)
+		edm.stop()
+		wg.Wait()
+
+		sentDir := t.TempDir()
+		oldFile := filepath.Join(sentDir, "dns_histogram-2026-05-28T12-00-00Z_2026-05-28T12-01-00Z.parquet")
+		if err := os.WriteFile(oldFile, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		oldTime := time.Now().Add(-13 * time.Hour)
+		if err := os.Chtimes(oldFile, oldTime, oldTime); err != nil {
+			t.Fatal(err)
+		}
+		edm.ctx, edm.stop = context.WithCancel(t.Context())
+		wg.Add(1)
+		go edm.diskCleaner(&wg, sentDir)
+		time.Sleep(time.Minute)
+		edm.stop()
+		wg.Wait()
+		if _, err := os.Stat(oldFile); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("old file still exists: %v", err)
+		}
+	})
+}
+
+func TestDataCollector(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		tc := defaultTC
+		edm := &dnstapMinimiser{
+			conf:               config{HistogramHLLExplicitThreshold: tc.CryptopanAddressEntries},
+			log:                slog.New(slog.NewTextHandler(io.Discard, nil)),
+			sessionCollectorCh: make(chan *sessionData, 1),
+			sessionWriterCh:    make(chan *prevSessions, 1),
+			histogramWriterCh:  make(chan *wellKnownDomainsData, 1),
+		}
+
+		path := testDawgFile(t, "example.com.")
+		finder, modTime, err := loadDawgFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wkd, err := newWellKnownDomainsTracker(finder, modTime)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go edm.dataCollector(&wg, wkd, path)
+
+		edm.sessionCollectorCh <- &sessionData{ServerID: ptr("server")}
+		wkd.updateCh <- wkdUpdate{
+			histogramData: histogramData{ACount: 1, OKCount: 1},
+			dawgIndex:     0,
+			dawgModTime:   modTime,
+			ip:            netip.MustParseAddr("198.51.100.20"),
+			hllHash:       1,
+		}
+		time.Sleep(timeUntilNextMinute())
+		close(wkd.stop)
+		wg.Wait()
+
+		if _, ok := <-edm.sessionWriterCh; !ok {
+			t.Fatal("sessionWriterCh closed before queued session could be read")
+		}
+		if _, ok := <-edm.histogramWriterCh; !ok {
+			t.Fatal("histogramWriterCh closed before queued histogram could be read")
+		}
+	})
+}
+
+func TestRunMinimiserFlows(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	edm.reloadMinimiserConfigCh = []chan struct{}{make(chan struct{}, 1)}
+	edm.newQnamePublisherCh = make(chan *protocols.NewQnameJSON, 1)
+	edm.sessionCollectorCh = make(chan *sessionData, 1)
+	cache, err := lru.New[string, struct{}](2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := newTestPebble(t)
+	finder := testDawgFinder(t, "known.example.")
+	wkd, err := newWellKnownDomainsTracker(finder, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go edm.runMinimiser(0, &wg, cache, db, nil, defaultLabelLimit, wkd)
+
+	queryFrame := marshaledDnstap(t, testDnstapMessage(t, dnstap.Message_CLIENT_QUERY, dnstap.SocketFamily_INET, packedDNSMsg(t, "query.example.", dns.TypeA, dns.RcodeSuccess)))
+	edm.inputChannel <- queryFrame
+
+	knownFrame := marshaledDnstap(t, testDnstapMessage(t, dnstap.Message_CLIENT_RESPONSE, dnstap.SocketFamily_INET, packedDNSMsg(t, "known.example.", dns.TypeA, dns.RcodeSuccess)))
+	edm.inputChannel <- knownFrame
+	select {
+	case <-wkd.updateCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for WKD update")
+	}
+
+	newFrame := marshaledDnstap(t, testDnstapMessage(t, dnstap.Message_CLIENT_RESPONSE, dnstap.SocketFamily_INET, packedDNSMsg(t, "new.example.", dns.TypeA, dns.RcodeSuccess)))
+	edm.inputChannel <- newFrame
+	select {
+	case ev := <-edm.newQnamePublisherCh:
+		if ev.Qname != "new.example." {
+			t.Fatalf("new qname = %s", ev.Qname)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for new_qname event")
+	}
+
+	select {
+	case sd := <-edm.sessionCollectorCh:
+		if sd.ResponseTime == nil {
+			t.Fatalf("session missing response time: %#v", sd)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for session")
+	}
+
+	edm.conf.DisableSessionFiles = true
+	edm.reloadMinimiserConfigCh[0] <- struct{}{}
+	edm.inputChannel <- newFrame
+	time.Sleep(20 * time.Millisecond)
+	select {
+	case sd := <-edm.sessionCollectorCh:
+		t.Fatalf("unexpected session while disabled: %#v", sd)
+	default:
+	}
+
+	edm.stop()
+	wg.Wait()
+}
+
+func TestRunMinimiserParseAndIgnoreFlows(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	edm.reloadMinimiserConfigCh = []chan struct{}{make(chan struct{}, 1)}
+	edm.newQnamePublisherCh = make(chan *protocols.NewQnameJSON)
+	edm.sessionCollectorCh = make(chan *sessionData)
+	cache, err := lru.New[string, struct{}](2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := newTestPebble(t)
+	wkd, err := newWellKnownDomainsTracker(testDawgFinder(t, "known.example."), time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var builder netipx.IPSetBuilder
+	builder.AddPrefix(netip.MustParsePrefix("198.51.100.20/32"))
+	edm.ignoredClientsIPSet, err = builder.IPSet()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go edm.runMinimiser(0, &wg, cache, db, nil, defaultLabelLimit, wkd)
+	edm.inputChannel <- []byte("not protobuf")
+	wg.Wait()
+
+	edm = newTestDnstapMinimiser(t, defaultTC)
+	edm.reloadMinimiserConfigCh = []chan struct{}{make(chan struct{}, 1)}
+	edm.newQnamePublisherCh = make(chan *protocols.NewQnameJSON)
+	edm.sessionCollectorCh = make(chan *sessionData)
+	edm.ignoredClientsIPSet, err = builder.IPSet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wg.Add(1)
+	go edm.runMinimiser(0, &wg, cache, db, nil, defaultLabelLimit, wkd)
+	edm.inputChannel <- marshaledDnstap(t, testDnstapMessage(t, dnstap.Message_CLIENT_RESPONSE, dnstap.SocketFamily_INET, packedDNSMsg(t, "ignored.example.", dns.TypeA, dns.RcodeSuccess)))
+	time.Sleep(20 * time.Millisecond)
+	edm.stop()
+	wg.Wait()
+}
+
+func TestRunWithDisabledSenders(t *testing.T) {
+	oldNotifyContext := notifyContext
+	oldListenAndServeHTTP := listenAndServeHTTP
+	t.Cleanup(func() {
+		notifyContext = oldNotifyContext
+		listenAndServeHTTP = oldListenAndServeHTTP
+		viper.Reset()
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	notifyContext = func(context.Context, ...os.Signal) (context.Context, context.CancelFunc) {
+		return ctx, cancel
+	}
+	listenAndServeHTTP = func(*http.Server) error {
+		return http.ErrServerClosed
+	}
+
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "edm.toml")
+	dawgFile := testDawgFile(t, "example.com.")
+	socketPath := filepath.Join(dir, "dnstap.sock")
+	configData := fmt.Sprintf(`
+config-file = %q
+disable-histogram-sender = true
+disable-mqtt = true
+input-unix = %q
+cryptopan-key = "key1"
+cryptopan-key-salt = "aabbccddeeffgghh"
+well-known-domains-file = %q
+histogram-hll-explicit-threshold = 20
+data-dir = %q
+minimiser-workers = 1
+qname-seen-entries = 2
+cryptopan-address-entries = 2
+newqname-buffer = 1
+`, configFile, socketPath, dawgFile, dir)
+	if err := os.WriteFile(configFile, []byte(configData), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	viper.SetConfigFile(configFile)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	level := new(slog.LevelVar)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		Run(logger, level)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not exit")
+	}
+}

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -696,10 +696,15 @@ func TestFSWatchersAndEventWatcher(t *testing.T) {
 	dir := t.TempDir()
 	watched := filepath.Join(dir, "watched.txt")
 	var calls atomic.Int32
+	callbackDone := make(chan struct{}, 1)
 	edm.fsWatcherFuncs = map[string][]func() error{
 		watched: {
 			func() error {
 				calls.Add(1)
+				select {
+				case callbackDone <- struct{}{}:
+				default:
+				}
 				return errors.New("logged")
 			},
 		},
@@ -712,7 +717,11 @@ func TestFSWatchersAndEventWatcher(t *testing.T) {
 		edm.fsEventWatcher()
 	}()
 	edm.fsWatcher.Events <- fsnotifyEvent(watched)
-	time.Sleep(150 * time.Millisecond)
+	select {
+	case <-callbackDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for watcher callback")
+	}
 	if calls.Load() != 1 {
 		t.Fatalf("watcher callbacks = %d, want 1", calls.Load())
 	}
@@ -958,15 +967,18 @@ func TestRunAutoPahoPublishPath(t *testing.T) {
 	edm.autopahoCtx, edm.autopahoCancel = context.WithCancel(t.Context())
 	t.Cleanup(edm.autopahoCancel)
 	jwk := testJWK(t)
-	conn := &fakeAutoPahoConnection{}
+	conn := &fakeAutoPahoConnection{publishedCh: make(chan struct{}, 1)}
 
 	edm.autopahoWg.Add(1)
 	go edm.runAutoPaho(conn, jwk, false)
 	edm.mqttPubCh <- []byte(`{"publish":"now"}`)
-	time.Sleep(20 * time.Millisecond)
+	select {
+	case <-conn.publishedCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for publish")
+	}
 	close(edm.mqttPubCh)
 	edm.autopahoWg.Wait()
-	time.Sleep(20 * time.Millisecond)
 
 	conn.mu.Lock()
 	published := len(conn.published)
@@ -988,10 +1000,11 @@ func TestRunAutoPahoAwaitError(t *testing.T) {
 }
 
 type fakeAutoPahoConnection struct {
-	mu        sync.Mutex
-	queued    []*autopaho.QueuePublish
-	published []*paho.Publish
-	awaitErr  error
+	mu          sync.Mutex
+	queued      []*autopaho.QueuePublish
+	published   []*paho.Publish
+	awaitErr    error
+	publishedCh chan struct{}
 }
 
 func (f *fakeAutoPahoConnection) AwaitConnection(context.Context) error {
@@ -1000,8 +1013,14 @@ func (f *fakeAutoPahoConnection) AwaitConnection(context.Context) error {
 
 func (f *fakeAutoPahoConnection) Publish(_ context.Context, p *paho.Publish) (*paho.PublishResponse, error) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.published = append(f.published, p)
+	f.mu.Unlock()
+	if f.publishedCh != nil {
+		select {
+		case f.publishedCh <- struct{}{}:
+		default:
+		}
+	}
 	return &paho.PublishResponse{}, nil
 }
 

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -3,17 +3,20 @@ package runner
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"flag"
 	"io"
 	"log/slog"
 	"net/netip"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	dnstap "github.com/dnstap/golang-dnstap"
+	"github.com/fsnotify/fsnotify"
 	"github.com/miekg/dns"
 	"github.com/parquet-go/parquet-go"
 	"github.com/parquet-go/parquet-go/format"
@@ -24,7 +27,7 @@ import (
 
 var (
 	testDawg     = flag.Bool("test-dawg", false, "perform tests requiring a well-known-domains.dawg file")
-	writeParquet = flag.Bool("write-parquet", false, "make parquet tests write out files in testdata directory")
+	writeParquet = flag.Bool("write-parquet", false, "make parquet tests write out files in a temporary directory")
 	defaultTC    = testConfiger{
 		CryptopanKey:            "key1",
 		CryptopanKeySalt:        "aabbccddeeffgghh",
@@ -34,6 +37,33 @@ var (
 		DisableMQTT:             false,
 	}
 )
+
+func newTestDnstapMinimiser(t testing.TB, tc testConfiger) *dnstapMinimiser {
+	t.Helper()
+
+	discardLogger := slog.NewTextHandler(io.Discard, nil)
+	logger := slog.New(discardLogger)
+
+	edm, err := newDnstapMinimiser(logger, tc)
+	if err != nil {
+		t.Fatalf("unable to setup edm: %s", err)
+	}
+
+	t.Cleanup(func() {
+		if edm.stop != nil {
+			edm.stop()
+		}
+		if edm.fsWatcher != nil {
+			if err := edm.fsWatcher.Close(); err != nil {
+				if !errors.Is(err, fsnotify.ErrClosed) {
+					t.Fatalf("unable to close fsWatcher: %s", err)
+				}
+			}
+		}
+	})
+
+	return edm
+}
 
 func BenchmarkWKDTLookup(b *testing.B) {
 	if !*testDawg {
@@ -216,19 +246,13 @@ func TestWKD(t *testing.T) {
 }
 
 func TestIgnoredClientIPsValid(t *testing.T) {
-	discardLogger := slog.NewTextHandler(io.Discard, nil)
-	logger := slog.New(discardLogger)
-
-	edm, err := newDnstapMinimiser(logger, defaultTC)
-	if err != nil {
-		t.Fatalf("unable to setup edm: %s", err)
-	}
+	edm := newTestDnstapMinimiser(t, defaultTC)
 
 	testdataFile1 := "testdata/ignored-client-ips.valid1"
 	testdataFile2 := "testdata/ignored-client-ips.valid2"
 
 	edm.conf.IgnoredClientIPsFile = testdataFile1
-	err = edm.setIgnoredClientIPs()
+	err := edm.setIgnoredClientIPs()
 	if err != nil {
 		t.Fatalf("unable to parse testdata: %s", err)
 	}
@@ -400,18 +424,12 @@ func TestIgnoredClientIPsValid(t *testing.T) {
 }
 
 func TestIgnoredClientIPsEmptyLinesComments(t *testing.T) {
-	discardLogger := slog.NewTextHandler(io.Discard, nil)
-	logger := slog.New(discardLogger)
-
-	edm, err := newDnstapMinimiser(logger, defaultTC)
-	if err != nil {
-		t.Fatalf("unable to setup edm: %s", err)
-	}
+	edm := newTestDnstapMinimiser(t, defaultTC)
 
 	testdataFile := "testdata/ignored-client-ips.empty-lines-and-comments"
 
 	edm.conf.IgnoredClientIPsFile = testdataFile
-	err = edm.setIgnoredClientIPs()
+	err := edm.setIgnoredClientIPs()
 	if err != nil {
 		t.Fatalf("unable to parse testdata: %s", err)
 	}
@@ -466,18 +484,12 @@ func TestIgnoredClientIPsEmptyLinesComments(t *testing.T) {
 }
 
 func TestIgnoredClientIPsEmpty(t *testing.T) {
-	discardLogger := slog.NewTextHandler(io.Discard, nil)
-	logger := slog.New(discardLogger)
-
-	edm, err := newDnstapMinimiser(logger, defaultTC)
-	if err != nil {
-		t.Fatalf("unable to setup edm: %s", err)
-	}
+	edm := newTestDnstapMinimiser(t, defaultTC)
 
 	testdataFile := "testdata/ignored-client-ips.valid1"
 	// To make sure reading an empty file resets stuff as expected first read in a file with content
 	edm.conf.IgnoredClientIPsFile = testdataFile
-	err = edm.setIgnoredClientIPs()
+	err := edm.setIgnoredClientIPs()
 	if err != nil {
 		t.Fatalf("unable to parse testdata: %s", err)
 	}
@@ -553,18 +565,12 @@ func TestIgnoredClientIPsEmpty(t *testing.T) {
 }
 
 func TestIgnoredClientIPsUnset(t *testing.T) {
-	discardLogger := slog.NewTextHandler(io.Discard, nil)
-	logger := slog.New(discardLogger)
-
-	edm, err := newDnstapMinimiser(logger, defaultTC)
-	if err != nil {
-		t.Fatalf("unable to setup edm: %s", err)
-	}
+	edm := newTestDnstapMinimiser(t, defaultTC)
 
 	// To make sure unsetting the filename used for ignored client IPs
 	// resets stuff as expected first read in a file with content
 	edm.conf.IgnoredClientIPsFile = "testdata/ignored-client-ips.valid1"
-	err = edm.setIgnoredClientIPs()
+	err := edm.setIgnoredClientIPs()
 	if err != nil {
 		t.Fatalf("unable to parse testdata: %s", err)
 	}
@@ -626,19 +632,13 @@ func TestIgnoredClientIPsUnset(t *testing.T) {
 }
 
 func TestIgnoredClientIPsInvalidClient(t *testing.T) {
-	discardLogger := slog.NewTextHandler(io.Discard, nil)
-	logger := slog.New(discardLogger)
-
-	edm, err := newDnstapMinimiser(logger, defaultTC)
-	if err != nil {
-		t.Fatalf("unable to setup edm: %s", err)
-	}
+	edm := newTestDnstapMinimiser(t, defaultTC)
 
 	// Even if we are testing invalid data we still need to have loaded a
 	// IP file with at least one valid entry in it to even inspect the
 	// value.
 	edm.conf.IgnoredClientIPsFile = "testdata/ignored-client-ips.valid1"
-	err = edm.setIgnoredClientIPs()
+	err := edm.setIgnoredClientIPs()
 	if err != nil {
 		t.Fatalf("unable to parse testdata: %s", err)
 	}
@@ -673,13 +673,7 @@ func TestIgnoredClientIPsInvalidClient(t *testing.T) {
 }
 
 func TestIgnoredQuestionNamesValid(t *testing.T) {
-	discardLogger := slog.NewTextHandler(io.Discard, nil)
-	logger := slog.New(discardLogger)
-
-	edm, err := newDnstapMinimiser(logger, defaultTC)
-	if err != nil {
-		t.Fatalf("unable to setup edm: %s", err)
-	}
+	edm := newTestDnstapMinimiser(t, defaultTC)
 
 	testdataFile1 := "testdata/ignored-question-names.valid1.dawg"
 	testdataFile2 := "testdata/ignored-question-names.valid2.dawg"
@@ -688,7 +682,7 @@ func TestIgnoredQuestionNamesValid(t *testing.T) {
 	expectedNumNames := 2
 
 	edm.conf.IgnoredQuestionNamesFile = testdataFile1
-	err = edm.setIgnoredQuestionNames()
+	err := edm.setIgnoredQuestionNames()
 	if err != nil {
 		t.Fatalf("unable to parse testdata: %s", err)
 	}
@@ -824,18 +818,12 @@ func TestIgnoredQuestionNamesValid(t *testing.T) {
 }
 
 func TestIgnoredQuestionNamesEmpty(t *testing.T) {
-	discardLogger := slog.NewTextHandler(io.Discard, nil)
-	logger := slog.New(discardLogger)
-
-	edm, err := newDnstapMinimiser(logger, defaultTC)
-	if err != nil {
-		t.Fatalf("unable to setup edm: %s", err)
-	}
+	edm := newTestDnstapMinimiser(t, defaultTC)
 
 	// To make sure reading an empty file resets stuff as expected first read in a file with content
 	testdataFile := "testdata/ignored-question-names.valid1.dawg"
 	edm.conf.IgnoredQuestionNamesFile = "testdata/ignored-question-names.valid1.dawg"
-	err = edm.setIgnoredQuestionNames()
+	err := edm.setIgnoredQuestionNames()
 	if err != nil {
 		t.Fatalf("unable to parse testdata: %s", err)
 	}
@@ -904,19 +892,13 @@ func TestIgnoredQuestionNamesEmpty(t *testing.T) {
 }
 
 func TestIgnoredQuestionNamesUnset(t *testing.T) {
-	discardLogger := slog.NewTextHandler(io.Discard, nil)
-	logger := slog.New(discardLogger)
-
-	edm, err := newDnstapMinimiser(logger, defaultTC)
-	if err != nil {
-		t.Fatalf("unable to setup edm: %s", err)
-	}
+	edm := newTestDnstapMinimiser(t, defaultTC)
 
 	// To make sure unsetting the filename used for ignored question names
 	// resets stuff as expected first read in a file with content
 	testdataFile := "testdata/ignored-question-names.valid1.dawg"
 	edm.conf.IgnoredQuestionNamesFile = testdataFile
-	err = edm.setIgnoredQuestionNames()
+	err := edm.setIgnoredQuestionNames()
 	if err != nil {
 		t.Fatalf("unable to parse testdata: %s", err)
 	}
@@ -1225,11 +1207,6 @@ func TestEDMIP6BytesToInt(t *testing.T) {
 }
 
 func TestPseudonymiseDnstap(t *testing.T) {
-	// Dont output logging
-	// https://github.com/golang/go/issues/62005
-	discardLogger := slog.NewTextHandler(io.Discard, nil)
-	logger := slog.New(discardLogger)
-
 	// The original addresses we want to pseudonymise
 	origQueryAddr4 := netip.MustParseAddr("198.51.100.20")
 	origRespAddr4 := netip.MustParseAddr("198.51.100.30")
@@ -1260,10 +1237,7 @@ func TestPseudonymiseDnstap(t *testing.T) {
 		},
 	}
 
-	edm, err := newDnstapMinimiser(logger, defaultTC)
-	if err != nil {
-		t.Fatalf("unable to setup edm: %s", err)
-	}
+	edm := newTestDnstapMinimiser(t, defaultTC)
 
 	if edm.cryptopanCache != nil {
 		if edm.cryptopanCache.Len() != 0 {
@@ -1383,7 +1357,7 @@ func TestPseudonymiseDnstap(t *testing.T) {
 	}
 
 	// Replace the cryptopan instance and verify we now get different pseudonymised results
-	err = edm.setCryptopan("key2", defaultTC.CryptopanKeySalt, defaultTC.CryptopanAddressEntries)
+	err := edm.setCryptopan("key2", defaultTC.CryptopanKeySalt, defaultTC.CryptopanAddressEntries)
 	if err != nil {
 		t.Fatalf("unable to call edm.SetCryptopan: %s", err)
 	}
@@ -1546,19 +1520,11 @@ func TestPseudonymiseDnstap(t *testing.T) {
 func BenchmarkPseudonymiseDnstapWithCache4(b *testing.B) {
 	b.ReportAllocs()
 
-	// Dont output logging
-	// https://github.com/golang/go/issues/62005
-	discardLogger := slog.NewTextHandler(io.Discard, nil)
-	logger := slog.New(discardLogger)
-
 	// The original addresses we want to pseudonymise
 	origQueryAddr4 := netip.MustParseAddr("198.51.100.20")
 	origRespAddr4 := netip.MustParseAddr("198.51.100.30")
 
-	edm, err := newDnstapMinimiser(logger, defaultTC)
-	if err != nil {
-		b.Fatalf("unable to setup edm: %s", err)
-	}
+	edm := newTestDnstapMinimiser(b, defaultTC)
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -1575,11 +1541,6 @@ func BenchmarkPseudonymiseDnstapWithCache4(b *testing.B) {
 func BenchmarkPseudonymiseDnstapWithoutCache4(b *testing.B) {
 	b.ReportAllocs()
 
-	// Dont output logging
-	// https://github.com/golang/go/issues/62005
-	discardLogger := slog.NewTextHandler(io.Discard, nil)
-	logger := slog.New(discardLogger)
-
 	// The original addresses we want to pseudonymise
 	origQueryAddr4 := netip.MustParseAddr("198.51.100.20")
 	origRespAddr4 := netip.MustParseAddr("198.51.100.30")
@@ -1587,10 +1548,7 @@ func BenchmarkPseudonymiseDnstapWithoutCache4(b *testing.B) {
 	uncachedTC := defaultTC
 	uncachedTC.CryptopanAddressEntries = 0
 
-	edm, err := newDnstapMinimiser(logger, uncachedTC)
-	if err != nil {
-		b.Fatalf("unable to setup edm: %s", err)
-	}
+	edm := newTestDnstapMinimiser(b, uncachedTC)
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -1607,19 +1565,11 @@ func BenchmarkPseudonymiseDnstapWithoutCache4(b *testing.B) {
 func BenchmarkPseudonymiseDnstapWithCache6(b *testing.B) {
 	b.ReportAllocs()
 
-	// Dont output logging
-	// https://github.com/golang/go/issues/62005
-	discardLogger := slog.NewTextHandler(io.Discard, nil)
-	logger := slog.New(discardLogger)
-
 	// The original addresses we want to pseudonymise
 	origQueryAddr6 := netip.MustParseAddr("2001:db8:1122:3344:5566:7788:99aa:bbcc")
 	origRespAddr6 := netip.MustParseAddr("2001:db8:1122:3344:5566:7788:99aa:ddee")
 
-	edm, err := newDnstapMinimiser(logger, defaultTC)
-	if err != nil {
-		b.Fatalf("unable to setup edm: %s", err)
-	}
+	edm := newTestDnstapMinimiser(b, defaultTC)
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -1636,11 +1586,6 @@ func BenchmarkPseudonymiseDnstapWithCache6(b *testing.B) {
 func BenchmarkPseudonymiseDnstapWithoutCache6(b *testing.B) {
 	b.ReportAllocs()
 
-	// Dont output logging
-	// https://github.com/golang/go/issues/62005
-	discardLogger := slog.NewTextHandler(io.Discard, nil)
-	logger := slog.New(discardLogger)
-
 	// The original addresses we want to pseudonymise
 	origQueryAddr6 := netip.MustParseAddr("2001:db8:1122:3344:5566:7788:99aa:bbcc")
 	origRespAddr6 := netip.MustParseAddr("2001:db8:1122:3344:5566:7788:99aa:ddee")
@@ -1648,10 +1593,7 @@ func BenchmarkPseudonymiseDnstapWithoutCache6(b *testing.B) {
 	uncachedTC := defaultTC
 	uncachedTC.CryptopanAddressEntries = 0
 
-	edm, err := newDnstapMinimiser(logger, uncachedTC)
-	if err != nil {
-		b.Fatalf("unable to setup edm: %s", err)
-	}
+	edm := newTestDnstapMinimiser(b, uncachedTC)
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -1819,7 +1761,7 @@ func TestSessionWriter(t *testing.T) {
 	}
 
 	if *writeParquet {
-		f, err := os.Create("testdata/generated-session.parquet")
+		f, err := os.Create(filepath.Join(t.TempDir(), "generated-session.parquet"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1894,7 +1836,7 @@ func TestHistogramWriter(t *testing.T) {
 	}
 
 	if *writeParquet {
-		f, err := os.Create("testdata/generated-histogram.parquet")
+		f, err := os.Create(filepath.Join(t.TempDir(), "generated-histogram.parquet"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2037,13 +1979,7 @@ func TestWriteHistogramParquetExplicitThreshold(t *testing.T) {
 	// Make sure we only include HLL data once the number of unique IPv4 or
 	// IPv6 client IPs exceed the configured explicit threshold where we
 	// start using probabilistic HLL data.
-	discardLogger := slog.NewTextHandler(io.Discard, nil)
-	logger := slog.New(discardLogger)
-
-	edm, err := newDnstapMinimiser(logger, defaultTC)
-	if err != nil {
-		t.Fatalf("unable to setup edm: %s", err)
-	}
+	edm := newTestDnstapMinimiser(t, defaultTC)
 
 	tests := []struct {
 		description       string

--- a/pkg/runner/seams.go
+++ b/pkg/runner/seams.go
@@ -1,0 +1,38 @@
+package runner
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/cockroachdb/pebble"
+	dnstap "github.com/dnstap/golang-dnstap"
+	"github.com/eclipse/paho.golang/autopaho"
+	"github.com/eclipse/paho.golang/autopaho/queue/file"
+	"github.com/fsnotify/fsnotify"
+)
+
+var (
+	exitProcess                     = os.Exit
+	notifyContext                   = signal.NotifyContext
+	newFSWatcher                    = fsnotify.NewWatcher
+	openPebble                      = pebble.Open
+	listenNet                       = net.Listen
+	listenTLS                       = tls.Listen
+	newFrameStreamSockInputFromPath = dnstap.NewFrameStreamSockInputFromPath
+	newFrameStreamSockInput         = dnstap.NewFrameStreamSockInput
+	listenAndServeHTTP              = func(s *http.Server) error { return s.ListenAndServe() }
+	newFileQueue                    = file.New
+	newAutoPahoConnection           = autopaho.NewConnection
+	now                             = time.Now
+	sleep                           = time.Sleep
+	configUpdateDebounce            = 100 * time.Millisecond
+	fsEventDebounce                 = 100 * time.Millisecond
+	diskCleanerInterval             = time.Minute
+	monitorChannelInterval          = time.Second
+	histogramSenderInterval         = 10 * time.Second
+	histogramSenderBackoff          = 15 * time.Second
+)


### PR DESCRIPTION
## Summary

This PR adds characterization tests for the current `pkg/` behavior without adding dependencies. It focuses on making the existing behavior explicit, improving repeat-test reliability, and adding small unexported seams where tests need to avoid process exits, real listeners, long timers, or external clients.

## What changed

- Added `pkg/cmd` tests for command execution, config initialization, flag binding, and the `run` command seam.
- Added `pkg/protocols` tests covering DNS flag encoding and `NewQnameEvent` construction.
- Added broad `pkg/runner` tests for:
  - ignored client IP and question-name cleanup paths
  - certificate/JWK/CA loading
  - DAWG loading/error behavior
  - parquet session and histogram writing
  - aggregate sender request behavior
  - MQTT config and publisher behavior
  - config watcher, fs watcher, disk cleanup, histogram sender, data collector, and minimiser flows
- Added unexported test seams for side-effectful paths such as process exit, signal context, fsnotify construction, Pebble open, listener/input creation, HTTP server startup, Paho connection creation, file queues, timers, and sleeps.
- Changed `runAutoPaho` to take a small unexported interface so tests can use a fake connection while production still passes `*autopaho.ConnectionManager`.
- Updated test helper setup so minimiser tests close `fsnotify.Watcher`s and stop signal contexts, preventing file descriptor exhaustion under repeated `go test` runs.
- Kept optional parquet debug output in `t.TempDir()` rather than writing generated files into `testdata`.
- Fixed `renameFile` so a missing source path returns an error instead of retrying forever after creating the destination directory.

## Why

The goal is to lock in current behavior and make future refactors safer. The existing test suite leaked file descriptors when run repeatedly with `-count`, and many side-effectful runner paths were previously hard to exercise without starting real services or exiting the process.

## Verification

- `go test ./pkg/... -count=20`
- `go test ./pkg/... -covermode=atomic -coverprofile=/tmp/edm-pkg.cover -count=1`
- `go tool cover -func=/tmp/edm-pkg.cover`
- `go test ./... -count=1`
- `go test ./pkg/... -race -count=1`

Coverage after this PR:

- `pkg/cmd`: 100.0%
- `pkg/protocols`: 100.0%
- `pkg/runner`: 76.8%
- total `pkg/`: 78.1%

This does not reach the originally requested 100% for all of `pkg/`; the remaining gap is concentrated in deeper `pkg/runner` orchestration and fatal/error branches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive unit tests for CLI initialization, configuration handling, protocol processing, and runner functionality with dependency injection patterns.

* **Refactor**
  * Restructured internal architecture to improve testability, error handling, and maintainability of core components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnstapir/edm/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->