### PR TITLE
Fix CI lint failures and update actions for Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,15 +11,15 @@ jobs:
       matrix:
         go-version: ['1.25.6']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
       - name: Display Go version
         run: go version
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: v2.4
           args: --timeout=5m

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Display Go version
         run: go version
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9.2.1
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: v2.4
           args: --timeout=5m

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,18 +11,18 @@ jobs:
       matrix:
         go-version: ['1.25.6']
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
           cache: false
       - name: Display Go version
         run: go version
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+        uses: golangci/golangci-lint-action@v9.2.1
         with:
           version: v2.4
           args: --timeout=5m

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,14 @@ jobs:
       matrix:
         go-version: ['1.25.6']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
+          cache: false
       - name: Display Go version
         run: go version
       - name: golangci-lint

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         name: Extract metadata
         id: meta
@@ -34,7 +34,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.25.6"
       - uses: ko-build/setup-ko@3aebd0597dc1e9d1a26bcfdb7cbeb19c131d3037 # v0.7

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -24,7 +24,9 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         name: Extract metadata
         id: meta
@@ -34,9 +36,10 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.6"
+          cache: false
       - uses: ko-build/setup-ko@3aebd0597dc1e9d1a26bcfdb7cbeb19c131d3037 # v0.7
       - run: ko build --base-import-paths --tags "$(printf '%s' "${{ steps.meta.outputs.tags }}" | tr '\n' ',')" github.com/dnstapir/edm/cmd/dnstapir-edm
         name: Build and push

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
@@ -36,7 +36,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.25.6"
           cache: false

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -158,8 +158,12 @@ func TestRunCommandUsesRunnerSeam(t *testing.T) {
 
 func TestRunFlagsBoundToViper(t *testing.T) {
 	t.Cleanup(func() {
-		_ = runCmd.Flags().Set("http-url", "https://127.0.0.1:8443")
-		_ = runCmd.Flags().Set("debug", "false")
+		if err := runCmd.Flags().Set("http-url", "https://127.0.0.1:8443"); err != nil {
+			t.Fatalf("reset http-url flag: %s", err)
+		}
+		if err := runCmd.Flags().Set("debug", "false"); err != nil {
+			t.Fatalf("reset debug flag: %s", err)
+		}
 	})
 
 	for _, name := range []string{"http-url", "debug"} {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -2356,7 +2356,9 @@ func (edm *dnstapMinimiser) manualParquetRotationHandler(w http.ResponseWriter, 
 			return
 		}
 		w.WriteHeader(http.StatusAccepted)
-		_, _ = w.Write([]byte("rotation requested\n"))
+		if _, err := w.Write([]byte("rotation requested\n")); err != nil {
+			edm.log.Error("manualParquetRotationHandler: failed to write response", "error", err)
+		}
 	case <-time.After(manualParquetRotationWaitTimeout):
 		http.Error(w, "timed out waiting for parquet rotation", http.StatusGatewayTimeout)
 	case <-r.Context().Done():

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -298,8 +298,8 @@ func TestCertPoolAndJWKFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(pool.Subjects()) == 0 {
-		t.Fatal("cert pool has no subjects")
+	if pool.Equal(x509.NewCertPool()) {
+		t.Fatal("cert pool has no certificates")
 	}
 
 	if _, err := certPoolFromFile(writeTempFile(t, "bad-ca.pem", []byte("not pem"))); err == nil {
@@ -332,14 +332,18 @@ func TestLoadDawgFileErrors(t *testing.T) {
 	if _, _, err := loadDawgFile(writeTempFile(t, "empty.dawg", nil)); !errors.Is(err, errEmptyDawgFile) {
 		t.Fatalf("empty DAWG error = %v", err)
 	}
-	func() {
+	recovered := func() (recovered any) {
 		defer func() {
-			if recover() == nil {
-				t.Fatal("invalid DAWG did not panic")
-			}
+			recovered = recover()
 		}()
-		_, _, _ = loadDawgFile(writeTempFile(t, "invalid.dawg", []byte("bad")))
+		if _, _, err := loadDawgFile(writeTempFile(t, "invalid.dawg", []byte("bad"))); err != nil {
+			t.Fatalf("invalid DAWG returned error instead of panic: %s", err)
+		}
+		return nil
 	}()
+	if recovered == nil {
+		t.Fatal("invalid DAWG did not panic")
+	}
 
 	finder, _, err := loadDawgFile(testDawgFile(t, "example.com."))
 	if err != nil {
@@ -926,14 +930,14 @@ func TestMQTTConfigAndPublisher(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.ClientConfig.ClientID != "client-id" || cfg.KeepAlive != 30 || cfg.TlsCfg.MinVersion != tls.VersionTLS13 {
+	if cfg.ClientID != "client-id" || cfg.KeepAlive != 30 || cfg.TlsCfg.MinVersion != tls.VersionTLS13 {
 		t.Fatalf("unexpected MQTT config: %#v", cfg)
 	}
 	cfg.OnConnectionUp(nil, nil)
 	cfg.OnConnectError(errors.New("connect"))
-	cfg.ClientConfig.OnClientError(errors.New("client"))
-	cfg.ClientConfig.OnServerDisconnect(&paho.Disconnect{ReasonCode: 1})
-	cfg.ClientConfig.OnServerDisconnect(&paho.Disconnect{Properties: &paho.DisconnectProperties{ReasonString: "bye"}})
+	cfg.OnClientError(errors.New("client"))
+	cfg.OnServerDisconnect(&paho.Disconnect{ReasonCode: 1})
+	cfg.OnServerDisconnect(&paho.Disconnect{Properties: &paho.DisconnectProperties{ReasonString: "bye"}})
 	if _, err := edm.newAutoPahoClientConfig(nil, "://bad", "client-id", 30, nil); err == nil {
 		t.Fatal("bad MQTT URL succeeded")
 	}


### PR DESCRIPTION
## Summary
- fix golangci-lint findings from failed build job
- update GitHub Actions to Node 24-compatible major versions

## Verification
- golangci-lint run --timeout=5m
- make test
- make build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed response body write error handling to properly report failures instead of silently ignoring them.

* **Tests**
  * Enhanced error validation in test cleanup procedures and panic detection for better test reliability.

* **Chores**
  * Updated CI/CD pipelines with newer versions of GitHub Actions and linting tools for improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnstapir/edm/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->