### PR TITLE
refactor(runner): make setupMQTT return an error (coverage stage 2)

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -664,13 +664,16 @@ func (edm *dnstapMinimiser) setupHistogramSender() error {
 	return nil
 }
 
-func (edm *dnstapMinimiser) setupMQTT() {
+// setupMQTT prepares the MQTT signing/publish pipeline from the current
+// config and starts it. It returns an error for any setup failure; callers
+// decide how to react (Run terminates the process). This mirrors the
+// error-returning style of setupHistogramSender.
+func (edm *dnstapMinimiser) setupMQTT() error {
 	conf := edm.getConfig()
 
 	mqttJWK, err := edDsaJWKFromFile(conf.MQTTSigningKeyFile)
 	if err != nil {
-		edm.log.Error("unable to parse jwk from 'mqtt-signing-key-file'", "error", err)
-		exitProcess(1)
+		return fmt.Errorf("setupMQTT: unable to parse jwk from 'mqtt-signing-key-file': %w", err)
 	}
 
 	// Leaving these nil will use the OS default CA certs
@@ -680,8 +683,7 @@ func (edm *dnstapMinimiser) setupMQTT() {
 		// Setup CA cert for validating the MQTT connection
 		mqttCACertPool, err = certPoolFromFile(conf.MQTTCAFile)
 		if err != nil {
-			edm.log.Error("failed to create CA cert pool for '--mqtt-ca-file'", "error", err)
-			exitProcess(1)
+			return fmt.Errorf("setupMQTT: failed to create CA cert pool for '--mqtt-ca-file': %w", err)
 		}
 	}
 
@@ -691,14 +693,12 @@ func (edm *dnstapMinimiser) setupMQTT() {
 
 		err = os.MkdirAll(mqttQueueDir, 0o750)
 		if err != nil {
-			edm.log.Error("unable to create MQTT queue dir", "error", err, "queue_dir", mqttQueueDir)
-			exitProcess(1)
+			return fmt.Errorf("setupMQTT: unable to create MQTT queue dir %q: %w", mqttQueueDir, err)
 		}
 
 		mqttFileQueue, err = newFileQueue(filepath.Join(conf.DataDir, "mqtt", "queue"), "queue", ".msg")
 		if err != nil {
-			edm.log.Error("unable to init MQTT queue file based queue", "error", err)
-			exitProcess(1)
+			return fmt.Errorf("setupMQTT: unable to init MQTT queue file based queue: %w", err)
 		}
 	}
 
@@ -708,16 +708,14 @@ func (edm *dnstapMinimiser) setupMQTT() {
 
 	autopahoConfig, err := edm.newAutoPahoClientConfig(mqttCACertPool, conf.MQTTServer, mqttClientID, conf.MQTTKeepalive, mqttFileQueue)
 	if err != nil {
-		edm.log.Error("unable to create autopaho config", "error", err)
-		exitProcess(1)
+		return fmt.Errorf("setupMQTT: unable to create autopaho config: %w", err)
 	}
 
 	edm.autopahoCtx, edm.autopahoCancel = context.WithCancel(context.Background())
 
 	autopahoCm, err := newAutoPahoConnection(edm.autopahoCtx, autopahoConfig)
 	if err != nil {
-		edm.log.Error("unable to create autopaho connection manager", "error", err)
-		exitProcess(1)
+		return fmt.Errorf("setupMQTT: unable to create autopaho connection manager: %w", err)
 	}
 
 	// Connect to the broker - this will return immediately after initiating the connection process.
@@ -726,6 +724,8 @@ func (edm *dnstapMinimiser) setupMQTT() {
 		signWorkers = runtime.GOMAXPROCS(0)
 	}
 	edm.startMQTTPipeline(autopahoCm, mqttJWK, mqttFileQueue != nil, signWorkers)
+
+	return nil
 }
 
 func (edm *dnstapMinimiser) loadHTTPClientCert() error {
@@ -1213,7 +1213,10 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 			exitProcess(1)
 		}
 
-		edm.setupMQTT()
+		if err := edm.setupMQTT(); err != nil {
+			edm.log.Error("unable to setup mqtt", "error", err)
+			exitProcess(1)
+		}
 	}
 
 	err = edm.configureFSWatchers(startConf)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -715,6 +715,9 @@ func (edm *dnstapMinimiser) setupMQTT() error {
 
 	autopahoCm, err := newAutoPahoConnection(edm.autopahoCtx, autopahoConfig)
 	if err != nil {
+		// Release the context created just above; on this error path the
+		// normal shutdown that would cancel it is never reached.
+		edm.autopahoCancel()
 		return fmt.Errorf("setupMQTT: unable to create autopaho connection manager: %w", err)
 	}
 

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -1097,39 +1097,78 @@ func TestSetupHistogramSenderAndCertLoaders(t *testing.T) {
 
 func TestSetupMQTT(t *testing.T) {
 	oldNewAutoPahoConnection := newAutoPahoConnection
-	oldExitProcess := exitProcess
 	t.Cleanup(func() {
 		newAutoPahoConnection = oldNewAutoPahoConnection
-		exitProcess = oldExitProcess
 	})
-
-	edm := newTestDnstapMinimiser(t, defaultTC)
-	edm.conf.DataDir = t.TempDir()
-	edm.conf.MQTTSigningKeyFile = testJWKFile(t)
-	edm.conf.MQTTServer = "mqtts://example.test:8883"
-	edm.conf.MQTTKeepalive = 30
-	edm.conf.DisableMQTTFilequeue = false
 	newAutoPahoConnection = func(context.Context, autopaho.ClientConfig) (*autopaho.ConnectionManager, error) {
 		return nil, nil
 	}
 
-	edm.setupMQTT()
-	close(edm.mqttPubCh)
-	edm.autopahoWg.Wait()
-	if edm.autopahoCancel == nil {
-		t.Fatal("autopaho cancel was not set")
-	}
+	t.Run("success", func(t *testing.T) {
+		edm := newTestDnstapMinimiser(t, defaultTC)
+		edm.conf.DataDir = t.TempDir()
+		edm.conf.MQTTSigningKeyFile = testJWKFile(t)
+		edm.conf.MQTTServer = "mqtts://example.test:8883"
+		edm.conf.MQTTKeepalive = 30
+		edm.conf.DisableMQTTFilequeue = false
+		edm.conf.MQTTSignWorkers = 0 // exercise the GOMAXPROCS default branch
 
-	exitProcess = func(int) { panic("exit") }
-	edm.conf.MQTTSigningKeyFile = filepath.Join(t.TempDir(), "missing.jwk")
-	func() {
-		defer func() {
-			if recover() == nil {
-				t.Fatal("setupMQTT did not exit on missing key")
-			}
-		}()
-		edm.setupMQTT()
-	}()
+		if err := edm.setupMQTT(); err != nil {
+			t.Fatalf("setupMQTT: %v", err)
+		}
+		close(edm.mqttPubCh)
+		edm.autopahoWg.Wait()
+		if edm.autopahoCancel == nil {
+			t.Fatal("autopaho cancel was not set")
+		}
+	})
+
+	t.Run("missing signing key", func(t *testing.T) {
+		edm := newTestDnstapMinimiser(t, defaultTC)
+		edm.conf.DataDir = t.TempDir()
+		edm.conf.MQTTSigningKeyFile = filepath.Join(t.TempDir(), "missing.jwk")
+		if err := edm.setupMQTT(); err == nil {
+			t.Fatal("setupMQTT succeeded with missing signing key")
+		}
+	})
+
+	t.Run("bad CA file", func(t *testing.T) {
+		edm := newTestDnstapMinimiser(t, defaultTC)
+		edm.conf.DataDir = t.TempDir()
+		edm.conf.MQTTSigningKeyFile = testJWKFile(t)
+		edm.conf.MQTTCAFile = writeTempFile(t, "bad-ca.pem", []byte("not a pem"))
+		if err := edm.setupMQTT(); err == nil {
+			t.Fatal("setupMQTT succeeded with bad CA file")
+		}
+	})
+
+	t.Run("queue dir creation failure", func(t *testing.T) {
+		edm := newTestDnstapMinimiser(t, defaultTC)
+		// Point DataDir below a regular file so MkdirAll fails with ENOTDIR
+		// regardless of the uid the tests run as.
+		blocker := writeTempFile(t, "blocker", []byte("x"))
+		edm.conf.DataDir = filepath.Join(blocker, "datadir")
+		edm.conf.MQTTSigningKeyFile = testJWKFile(t)
+		edm.conf.DisableMQTTFilequeue = false
+		if err := edm.setupMQTT(); err == nil {
+			t.Fatal("setupMQTT succeeded with un-creatable queue dir")
+		}
+	})
+
+	t.Run("connection manager failure", func(t *testing.T) {
+		oldConn := newAutoPahoConnection
+		t.Cleanup(func() { newAutoPahoConnection = oldConn })
+		newAutoPahoConnection = func(context.Context, autopaho.ClientConfig) (*autopaho.ConnectionManager, error) {
+			return nil, errors.New("connect boom")
+		}
+		edm := newTestDnstapMinimiser(t, defaultTC)
+		edm.conf.DataDir = t.TempDir()
+		edm.conf.MQTTSigningKeyFile = testJWKFile(t)
+		edm.conf.DisableMQTTFilequeue = true
+		if err := edm.setupMQTT(); err == nil {
+			t.Fatal("setupMQTT succeeded despite connection manager error")
+		}
+	})
 }
 
 type sequenceConfiger struct {

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -1028,8 +1028,14 @@ func (f *fakeAutoPahoConnection) Publish(_ context.Context, p *paho.Publish) (*p
 
 func (f *fakeAutoPahoConnection) PublishViaQueue(_ context.Context, p *autopaho.QueuePublish) error {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.queued = append(f.queued, p)
+	f.mu.Unlock()
+	if f.publishedCh != nil {
+		select {
+		case f.publishedCh <- struct{}{}:
+		default:
+		}
+	}
 	return nil
 }
 
@@ -1100,11 +1106,13 @@ func TestSetupMQTT(t *testing.T) {
 	t.Cleanup(func() {
 		newAutoPahoConnection = oldNewAutoPahoConnection
 	})
-	newAutoPahoConnection = func(context.Context, autopaho.ClientConfig) (*autopaho.ConnectionManager, error) {
-		return nil, nil
-	}
 
 	t.Run("success", func(t *testing.T) {
+		conn := &fakeAutoPahoConnection{publishedCh: make(chan struct{}, 1)}
+		newAutoPahoConnection = func(context.Context, autopaho.ClientConfig) (mqttConnectionManager, error) {
+			return conn, nil
+		}
+
 		edm := newTestDnstapMinimiser(t, defaultTC)
 		edm.conf.DataDir = t.TempDir()
 		edm.conf.MQTTSigningKeyFile = testJWKFile(t)
@@ -1116,10 +1124,24 @@ func TestSetupMQTT(t *testing.T) {
 		if err := edm.setupMQTT(); err != nil {
 			t.Fatalf("setupMQTT: %v", err)
 		}
+		// Drive the publish path so the fake connection manager is actually
+		// exercised; otherwise the worker would exit before touching cm.
+		edm.mqttPubCh <- []byte(`{"hello":"world"}`)
+		select {
+		case <-conn.publishedCh:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for publish")
+		}
 		close(edm.mqttPubCh)
 		edm.autopahoWg.Wait()
 		if edm.autopahoCancel == nil {
 			t.Fatal("autopaho cancel was not set")
+		}
+		conn.mu.Lock()
+		queued := len(conn.queued)
+		conn.mu.Unlock()
+		if queued != 1 {
+			t.Fatalf("queued messages = %d, want 1", queued)
 		}
 	})
 
@@ -1162,7 +1184,7 @@ func TestSetupMQTT(t *testing.T) {
 		oldConn := newAutoPahoConnection
 		t.Cleanup(func() { newAutoPahoConnection = oldConn })
 		errConnect := errors.New("connect boom")
-		newAutoPahoConnection = func(context.Context, autopaho.ClientConfig) (*autopaho.ConnectionManager, error) {
+		newAutoPahoConnection = func(context.Context, autopaho.ClientConfig) (mqttConnectionManager, error) {
 			return nil, errConnect
 		}
 		edm := newTestDnstapMinimiser(t, defaultTC)

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -1127,8 +1127,9 @@ func TestSetupMQTT(t *testing.T) {
 		edm := newTestDnstapMinimiser(t, defaultTC)
 		edm.conf.DataDir = t.TempDir()
 		edm.conf.MQTTSigningKeyFile = filepath.Join(t.TempDir(), "missing.jwk")
-		if err := edm.setupMQTT(); err == nil {
-			t.Fatal("setupMQTT succeeded with missing signing key")
+		err := edm.setupMQTT()
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("setupMQTT error = %v, want os.ErrNotExist", err)
 		}
 	})
 
@@ -1137,8 +1138,9 @@ func TestSetupMQTT(t *testing.T) {
 		edm.conf.DataDir = t.TempDir()
 		edm.conf.MQTTSigningKeyFile = testJWKFile(t)
 		edm.conf.MQTTCAFile = writeTempFile(t, "bad-ca.pem", []byte("not a pem"))
-		if err := edm.setupMQTT(); err == nil {
-			t.Fatal("setupMQTT succeeded with bad CA file")
+		err := edm.setupMQTT()
+		if err == nil || !strings.Contains(err.Error(), "CA cert pool") {
+			t.Fatalf("setupMQTT error = %v, want CA cert pool failure", err)
 		}
 	})
 
@@ -1150,23 +1152,26 @@ func TestSetupMQTT(t *testing.T) {
 		edm.conf.DataDir = filepath.Join(blocker, "datadir")
 		edm.conf.MQTTSigningKeyFile = testJWKFile(t)
 		edm.conf.DisableMQTTFilequeue = false
-		if err := edm.setupMQTT(); err == nil {
-			t.Fatal("setupMQTT succeeded with un-creatable queue dir")
+		err := edm.setupMQTT()
+		if err == nil || !strings.Contains(err.Error(), "queue dir") {
+			t.Fatalf("setupMQTT error = %v, want queue dir failure", err)
 		}
 	})
 
 	t.Run("connection manager failure", func(t *testing.T) {
 		oldConn := newAutoPahoConnection
 		t.Cleanup(func() { newAutoPahoConnection = oldConn })
+		errConnect := errors.New("connect boom")
 		newAutoPahoConnection = func(context.Context, autopaho.ClientConfig) (*autopaho.ConnectionManager, error) {
-			return nil, errors.New("connect boom")
+			return nil, errConnect
 		}
 		edm := newTestDnstapMinimiser(t, defaultTC)
 		edm.conf.DataDir = t.TempDir()
 		edm.conf.MQTTSigningKeyFile = testJWKFile(t)
 		edm.conf.DisableMQTTFilequeue = true
-		if err := edm.setupMQTT(); err == nil {
-			t.Fatal("setupMQTT succeeded despite connection manager error")
+		err := edm.setupMQTT()
+		if !errors.Is(err, errConnect) {
+			t.Fatalf("setupMQTT error = %v, want %v", err, errConnect)
 		}
 	})
 }

--- a/pkg/runner/seams.go
+++ b/pkg/runner/seams.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"context"
 	"crypto/tls"
 	"net"
 	"net/http"
@@ -26,13 +27,15 @@ var (
 	newFrameStreamSockInput         = dnstap.NewFrameStreamSockInput
 	listenAndServeHTTP              = func(s *http.Server) error { return s.ListenAndServe() }
 	newFileQueue                    = file.New
-	newAutoPahoConnection           = autopaho.NewConnection
-	now                             = time.Now
-	sleep                           = time.Sleep
-	configUpdateDebounce            = 100 * time.Millisecond
-	fsEventDebounce                 = 100 * time.Millisecond
-	diskCleanerInterval             = time.Minute
-	monitorChannelInterval          = time.Second
-	histogramSenderInterval         = 10 * time.Second
-	histogramSenderBackoff          = 15 * time.Second
+	newAutoPahoConnection           = func(ctx context.Context, cfg autopaho.ClientConfig) (mqttConnectionManager, error) {
+		return autopaho.NewConnection(ctx, cfg)
+	}
+	now                     = time.Now
+	sleep                   = time.Sleep
+	configUpdateDebounce    = 100 * time.Millisecond
+	fsEventDebounce         = 100 * time.Millisecond
+	diskCleanerInterval     = time.Minute
+	monitorChannelInterval  = time.Second
+	histogramSenderInterval = 10 * time.Second
+	histogramSenderBackoff  = 15 * time.Second
 )


### PR DESCRIPTION
## What

Stage 2 of the staged coverage effort. `setupMQTT` was the only setup helper that called `exitProcess(1)` **directly** on failure, which forced its error branches to be tested via `panic`/`recover`.

- Change `setupMQTT()` → `setupMQTT() error`, replacing each `exitProcess(1)` with a wrapped `fmt.Errorf(...)` (mirroring the existing `setupHistogramSender`).
- `Run` maps the returned error to `exitProcess(1)` at the call site.

**Behavior is unchanged** — any setup failure still terminates the process, one stack frame up.

## Tests

`TestSetupMQTT` rewritten to assert returned errors instead of recovering from a panic, and extended to cover: missing signing key, bad CA file, queue-dir creation failure (`DataDir` placed below a regular file → `ENOTDIR`, root-safe), connection-manager failure (via the `newAutoPahoConnection` seam), and the `MQTTSignWorkers <= 0` → `GOMAXPROCS` default.

## Coverage

- `setupMQTT`: **67.6% → 93.8%** (residual: the `newAutoPahoClientConfig` branch, impractical to trigger).
- `pkg/runner`: 77.4% → 78.0%.

## Verification

`go test -race ./pkg/runner/` green; `golangci-lint run ./pkg/runner/` reports 0 issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * MQTT setup now returns errors instead of forcing immediate termination; initialization failures are propagated and resources are properly cleaned up on failure.
* **Tests**
  * Improved tests for MQTT setup with subtests and explicit cleanup; covers success and multiple failure scenarios to validate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->