### PR TITLE
test(runner): file-op seams + cover writer error branches (coverage stage 3)

### DIFF
--- a/pkg/runner/fileops_test.go
+++ b/pkg/runner/fileops_test.go
@@ -14,8 +14,14 @@ import (
 	"time"
 )
 
-// discardEDM returns a minimal minimiser with a no-op logger, enough for
-// exercising the file-operation helpers that only touch edm.log.
+// errInjected is the sentinel failure injected through the file-op seams so
+// the error-path assertions can confirm (via errors.Is) that the injected
+// failure is the one surfaced, rather than some unrelated error.
+var errInjected = errors.New("injected failure")
+
+// discardEDM returns a minimal minimiser with a no-op logger. It intentionally
+// only sets the logger, which is all the file-operation helpers under test
+// touch; it deliberately does not go through newTestDnstapMinimiser.
 func discardEDM() *dnstapMinimiser {
 	return &dnstapMinimiser{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
 }
@@ -47,22 +53,20 @@ func TestCreateFile(t *testing.T) {
 
 	t.Run("mkdir failure is reported", func(t *testing.T) {
 		edm := discardEDM()
-		swapSeam(t, &osMkdirAll, func(string, os.FileMode) error {
-			return errors.New("mkdir boom")
-		})
+		swapSeam(t, &osMkdirAll, func(string, os.FileMode) error { return errInjected })
 		dst := filepath.Join(t.TempDir(), "missing", "out.parquet")
-		if _, err := edm.createFile(dst); err == nil {
-			t.Fatal("createFile succeeded despite mkdir failure")
+		_, err := edm.createFile(dst)
+		if !errors.Is(err, errInjected) {
+			t.Fatalf("createFile error = %v, want %v", err, errInjected)
 		}
 	})
 
 	t.Run("non-ENOENT create error is reported", func(t *testing.T) {
 		edm := discardEDM()
-		swapSeam(t, &osCreate, func(string) (*os.File, error) {
-			return nil, errors.New("permission boom")
-		})
-		if _, err := edm.createFile(filepath.Join(t.TempDir(), "out.parquet")); err == nil {
-			t.Fatal("createFile succeeded despite create error")
+		swapSeam(t, &osCreate, func(string) (*os.File, error) { return nil, errInjected })
+		_, err := edm.createFile(filepath.Join(t.TempDir(), "out.parquet"))
+		if !errors.Is(err, errInjected) {
+			t.Fatalf("createFile error = %v, want %v", err, errInjected)
 		}
 	})
 }
@@ -83,21 +87,28 @@ func TestRenameFile(t *testing.T) {
 
 	t.Run("dest dir exists but rename fails", func(t *testing.T) {
 		edm := discardEDM()
+		// A real FileInfo (not (nil,nil)) so the stub matches os.Stat's
+		// contract; osStat returning a nil error breaks the retry loop and
+		// makes renameFile surface the rename error (here fs.ErrNotExist).
+		info, statErr := os.Stat(t.TempDir())
+		if statErr != nil {
+			t.Fatal(statErr)
+		}
 		swapSeam(t, &osRename, func(string, string) error { return fs.ErrNotExist })
-		swapSeam(t, &osStat, func(string) (os.FileInfo, error) { return nil, nil })
-		if err := edm.renameFile("src", "dst"); err == nil {
-			t.Fatal("renameFile succeeded despite persistent rename failure")
+		swapSeam(t, &osStat, func(string) (os.FileInfo, error) { return info, nil })
+		err := edm.renameFile("src", "dst")
+		if !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("renameFile error = %v, want fs.ErrNotExist", err)
 		}
 	})
 
 	t.Run("stat error is reported", func(t *testing.T) {
 		edm := discardEDM()
 		swapSeam(t, &osRename, func(string, string) error { return fs.ErrNotExist })
-		swapSeam(t, &osStat, func(string) (os.FileInfo, error) {
-			return nil, errors.New("stat boom")
-		})
-		if err := edm.renameFile("src", "dst"); err == nil {
-			t.Fatal("renameFile succeeded despite stat error")
+		swapSeam(t, &osStat, func(string) (os.FileInfo, error) { return nil, errInjected })
+		err := edm.renameFile("src", "dst")
+		if !errors.Is(err, errInjected) {
+			t.Fatalf("renameFile error = %v, want %v", err, errInjected)
 		}
 	})
 
@@ -105,21 +116,19 @@ func TestRenameFile(t *testing.T) {
 		edm := discardEDM()
 		swapSeam(t, &osRename, func(string, string) error { return fs.ErrNotExist })
 		swapSeam(t, &osStat, func(string) (os.FileInfo, error) { return nil, fs.ErrNotExist })
-		swapSeam(t, &osMkdirAll, func(string, os.FileMode) error {
-			return errors.New("mkdir boom")
-		})
-		if err := edm.renameFile("src", "dst"); err == nil {
-			t.Fatal("renameFile succeeded despite mkdir failure")
+		swapSeam(t, &osMkdirAll, func(string, os.FileMode) error { return errInjected })
+		err := edm.renameFile("src", "dst")
+		if !errors.Is(err, errInjected) {
+			t.Fatalf("renameFile error = %v, want %v", err, errInjected)
 		}
 	})
 
 	t.Run("non-ENOENT rename error is reported", func(t *testing.T) {
 		edm := discardEDM()
-		swapSeam(t, &osRename, func(string, string) error {
-			return errors.New("rename boom")
-		})
-		if err := edm.renameFile("src", "dst"); err == nil {
-			t.Fatal("renameFile succeeded despite rename error")
+		swapSeam(t, &osRename, func(string, string) error { return errInjected })
+		err := edm.renameFile("src", "dst")
+		if !errors.Is(err, errInjected) {
+			t.Fatalf("renameFile error = %v, want %v", err, errInjected)
 		}
 	})
 }
@@ -132,9 +141,7 @@ func TestSessionWriterLogsCreateError(t *testing.T) {
 	var buf bytes.Buffer
 	edm.log = slog.New(slog.NewJSONHandler(&buf, nil))
 
-	swapSeam(t, &osCreate, func(string) (*os.File, error) {
-		return nil, errors.New("create boom")
-	})
+	swapSeam(t, &osCreate, func(string) (*os.File, error) { return nil, errInjected })
 
 	edm.sessionWriterCh <- &prevSessions{rotationTime: time.Now()}
 	close(edm.sessionWriterCh)
@@ -142,6 +149,8 @@ func TestSessionWriterLogsCreateError(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go edm.sessionWriter(t.TempDir(), &wg)
+	// waitForWaitGroup blocks until wg.Done(), establishing happens-before for
+	// the buffer read below (the worker's last write precedes its Done()).
 	waitForWaitGroup(t, &wg, 5*time.Second, "sessionWriter did not exit")
 
 	if !strings.Contains(buf.String(), `"level":"ERROR"`) || !strings.Contains(buf.String(), "sessionWriter") {
@@ -156,9 +165,7 @@ func TestHistogramWriterLogsCreateError(t *testing.T) {
 	var buf bytes.Buffer
 	edm.log = slog.New(slog.NewJSONHandler(&buf, nil))
 
-	swapSeam(t, &osCreate, func(string) (*os.File, error) {
-		return nil, errors.New("create boom")
-	})
+	swapSeam(t, &osCreate, func(string) (*os.File, error) { return nil, errInjected })
 
 	edm.histogramWriterCh <- &wellKnownDomainsData{
 		rotationTime: time.Now(),

--- a/pkg/runner/fileops_test.go
+++ b/pkg/runner/fileops_test.go
@@ -1,0 +1,177 @@
+package runner
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// discardEDM returns a minimal minimiser with a no-op logger, enough for
+// exercising the file-operation helpers that only touch edm.log.
+func discardEDM() *dnstapMinimiser {
+	return &dnstapMinimiser{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+// swapSeam temporarily replaces a seam variable for the duration of the test.
+func swapSeam[T any](t *testing.T, target *T, replacement T) {
+	t.Helper()
+	old := *target
+	*target = replacement
+	t.Cleanup(func() { *target = old })
+}
+
+func TestCreateFile(t *testing.T) {
+	t.Run("creates missing parent dir and retries", func(t *testing.T) {
+		edm := discardEDM()
+		dst := filepath.Join(t.TempDir(), "missing", "sub", "out.parquet")
+
+		f, err := edm.createFile(dst)
+		if err != nil {
+			t.Fatalf("createFile: %v", err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+		if _, err := os.Stat(dst); err != nil {
+			t.Fatalf("expected file to exist: %v", err)
+		}
+	})
+
+	t.Run("mkdir failure is reported", func(t *testing.T) {
+		edm := discardEDM()
+		swapSeam(t, &osMkdirAll, func(string, os.FileMode) error {
+			return errors.New("mkdir boom")
+		})
+		dst := filepath.Join(t.TempDir(), "missing", "out.parquet")
+		if _, err := edm.createFile(dst); err == nil {
+			t.Fatal("createFile succeeded despite mkdir failure")
+		}
+	})
+
+	t.Run("non-ENOENT create error is reported", func(t *testing.T) {
+		edm := discardEDM()
+		swapSeam(t, &osCreate, func(string) (*os.File, error) {
+			return nil, errors.New("permission boom")
+		})
+		if _, err := edm.createFile(filepath.Join(t.TempDir(), "out.parquet")); err == nil {
+			t.Fatal("createFile succeeded despite create error")
+		}
+	})
+}
+
+func TestRenameFile(t *testing.T) {
+	t.Run("creates missing dest dir and retries", func(t *testing.T) {
+		edm := discardEDM()
+		src := writeTempFile(t, "src", []byte("payload"))
+		dst := filepath.Join(t.TempDir(), "newdir", "dst")
+
+		if err := edm.renameFile(src, dst); err != nil {
+			t.Fatalf("renameFile: %v", err)
+		}
+		if _, err := os.Stat(dst); err != nil {
+			t.Fatalf("expected renamed file: %v", err)
+		}
+	})
+
+	t.Run("dest dir exists but rename fails", func(t *testing.T) {
+		edm := discardEDM()
+		swapSeam(t, &osRename, func(string, string) error { return fs.ErrNotExist })
+		swapSeam(t, &osStat, func(string) (os.FileInfo, error) { return nil, nil })
+		if err := edm.renameFile("src", "dst"); err == nil {
+			t.Fatal("renameFile succeeded despite persistent rename failure")
+		}
+	})
+
+	t.Run("stat error is reported", func(t *testing.T) {
+		edm := discardEDM()
+		swapSeam(t, &osRename, func(string, string) error { return fs.ErrNotExist })
+		swapSeam(t, &osStat, func(string) (os.FileInfo, error) {
+			return nil, errors.New("stat boom")
+		})
+		if err := edm.renameFile("src", "dst"); err == nil {
+			t.Fatal("renameFile succeeded despite stat error")
+		}
+	})
+
+	t.Run("mkdir failure is reported", func(t *testing.T) {
+		edm := discardEDM()
+		swapSeam(t, &osRename, func(string, string) error { return fs.ErrNotExist })
+		swapSeam(t, &osStat, func(string) (os.FileInfo, error) { return nil, fs.ErrNotExist })
+		swapSeam(t, &osMkdirAll, func(string, os.FileMode) error {
+			return errors.New("mkdir boom")
+		})
+		if err := edm.renameFile("src", "dst"); err == nil {
+			t.Fatal("renameFile succeeded despite mkdir failure")
+		}
+	})
+
+	t.Run("non-ENOENT rename error is reported", func(t *testing.T) {
+		edm := discardEDM()
+		swapSeam(t, &osRename, func(string, string) error {
+			return errors.New("rename boom")
+		})
+		if err := edm.renameFile("src", "dst"); err == nil {
+			t.Fatal("renameFile succeeded despite rename error")
+		}
+	})
+}
+
+// TestSessionWriterLogsCreateError verifies the sessionWriter worker logs and
+// keeps running when createSessionFile fails. The failure is injected via the
+// osCreate seam so writeSessionParquet is never reached.
+func TestSessionWriterLogsCreateError(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	var buf bytes.Buffer
+	edm.log = slog.New(slog.NewJSONHandler(&buf, nil))
+
+	swapSeam(t, &osCreate, func(string) (*os.File, error) {
+		return nil, errors.New("create boom")
+	})
+
+	edm.sessionWriterCh <- &prevSessions{rotationTime: time.Now()}
+	close(edm.sessionWriterCh)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go edm.sessionWriter(t.TempDir(), &wg)
+	waitForWaitGroup(t, &wg, 5*time.Second, "sessionWriter did not exit")
+
+	if !strings.Contains(buf.String(), `"level":"ERROR"`) || !strings.Contains(buf.String(), "sessionWriter") {
+		t.Fatalf("expected error log from sessionWriter, got: %q", buf.String())
+	}
+}
+
+// TestHistogramWriterLogsCreateError mirrors the session writer test for the
+// histogram writer worker.
+func TestHistogramWriterLogsCreateError(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	var buf bytes.Buffer
+	edm.log = slog.New(slog.NewJSONHandler(&buf, nil))
+
+	swapSeam(t, &osCreate, func(string) (*os.File, error) {
+		return nil, errors.New("create boom")
+	})
+
+	edm.histogramWriterCh <- &wellKnownDomainsData{
+		rotationTime: time.Now(),
+		m:            map[int]*histogramData{},
+	}
+	close(edm.histogramWriterCh)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go edm.histogramWriter(defaultLabelLimit, t.TempDir(), &wg)
+	waitForWaitGroup(t, &wg, 5*time.Second, "histogramWriter did not exit")
+
+	if !strings.Contains(buf.String(), `"level":"ERROR"`) || !strings.Contains(buf.String(), "histogramWriter") {
+		t.Fatalf("expected error log from histogramWriter, got: %q", buf.String())
+	}
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -387,7 +387,7 @@ timerLoop:
 	for {
 		select {
 		case <-ticker.C:
-			dirEntries, err := os.ReadDir(sentDir)
+			dirEntries, err := osReadDir(sentDir)
 			if err != nil {
 				if errors.Is(err, fs.ErrNotExist) {
 					// The directory has not been created yet, this is OK
@@ -410,7 +410,7 @@ timerLoop:
 					if time.Since(fileInfo.ModTime()) > oneDay {
 						absPath := filepath.Join(sentDir, dirEntry.Name())
 						edm.log.Info("diskCleaner: removing file", "filename", absPath)
-						err = os.Remove(absPath)
+						err = osRemove(absPath)
 						if err != nil {
 							edm.log.Error("diskCleaner: unable to remove sent histogram file", "error", err)
 						}
@@ -2215,7 +2215,7 @@ func (edm *dnstapMinimiser) createSessionFile(ps *prevSessions, dataDir string) 
 		}
 		if writeFailed {
 			edm.log.Info("createSessionFile: cleaning up file because write failed", "filename", outFile.Name())
-			err = os.Remove(outFile.Name())
+			err = osRemove(outFile.Name())
 			if err != nil {
 				edm.log.Error("createSessionFile: unable to remove session outFile", "error", err, "filename", outFile.Name())
 			}
@@ -2240,7 +2240,7 @@ func (edm *dnstapMinimiser) createSessionFile(ps *prevSessions, dataDir string) 
 
 	// Atomically rename the file to its real name so it can be picked up by the histogram sender
 	edm.log.Info("renaming session file", "from", absoluteTmpFileName, "to", absoluteFileName)
-	err = os.Rename(absoluteTmpFileName, absoluteFileName)
+	err = osRename(absoluteTmpFileName, absoluteFileName)
 	if err != nil {
 		return "", fmt.Errorf("createSessionFile: unable to rename output file: %w", err)
 	}
@@ -2288,7 +2288,7 @@ func (edm *dnstapMinimiser) createHistogramFile(prevWellKnownDomainsData *wellKn
 		}
 		if writeFailed {
 			edm.log.Info("createHistogramFile: cleaning up file because write failed", "filename", outFile.Name())
-			err = os.Remove(outFile.Name())
+			err = osRemove(outFile.Name())
 			if err != nil {
 				edm.log.Error("createHistogramFile: unable to remove histogram outFile", "error", err, "filename", outFile.Name())
 			}
@@ -2313,7 +2313,7 @@ func (edm *dnstapMinimiser) createHistogramFile(prevWellKnownDomainsData *wellKn
 
 	// Atomically rename the file to its real name so it can be picked up by the histogram sender
 	edm.log.Info("renaming histogram file", "from", absoluteTmpFileName, "to", absoluteFileName)
-	err = os.Rename(absoluteTmpFileName, absoluteFileName)
+	err = osRename(absoluteTmpFileName, absoluteFileName)
 	if err != nil {
 		return "", fmt.Errorf("createHistogramFile: unable to rename output file: %w", err)
 	}
@@ -2380,14 +2380,14 @@ func (edm *dnstapMinimiser) renameFile(src string, dst string) error {
 	// We are prepared for the destination directory not existing and will
 	// create it if needed and retry the rename in this case.
 	for {
-		err := os.Rename(src, dst)
+		err := osRename(src, dst)
 		if err == nil {
 			// Rename went well, we are done
 			return nil
 		}
 
 		if errors.Is(err, fs.ErrNotExist) {
-			if _, statErr := os.Stat(dstDir); statErr == nil {
+			if _, statErr := osStat(dstDir); statErr == nil {
 				return fmt.Errorf("renameFile: unable to rename file, src: %s, dst: %s: %w", src, dst, err)
 			} else if !errors.Is(statErr, fs.ErrNotExist) {
 				return fmt.Errorf("renameFile: unable to stat destination dir: %s: %w", dstDir, statErr)
@@ -2395,7 +2395,7 @@ func (edm *dnstapMinimiser) renameFile(src string, dst string) error {
 			// If the destination directory does not exist we will
 			// need to create it and then retry the Rename() in the
 			// next iteration of the loop.
-			err = os.MkdirAll(dstDir, 0o750)
+			err = osMkdirAll(dstDir, 0o750)
 			if err != nil {
 				return fmt.Errorf("renameFile: unable to create destination dir: %s: %w", dstDir, err)
 			}
@@ -2416,7 +2416,7 @@ func (edm *dnstapMinimiser) createFile(dst string) (*os.File, error) {
 	// We are prepared for the destination directory not existing and will
 	// create it if needed and retry the creation in this case.
 	for {
-		outFile, err := os.Create(dst)
+		outFile, err := osCreate(dst)
 		if err == nil {
 			// Creation went well, we are done
 			return outFile, nil
@@ -2426,7 +2426,7 @@ func (edm *dnstapMinimiser) createFile(dst string) (*os.File, error) {
 			// If the destination directory does not exist we will
 			// need to create it and then retry the file Create()
 			// the next iteration of the loop.
-			err = os.MkdirAll(dstDir, 0o750)
+			err = osMkdirAll(dstDir, 0o750)
 			if err != nil {
 				return nil, fmt.Errorf("createFile: unable to create destination dir: %s: %w", dstDir, err)
 			}
@@ -2463,7 +2463,7 @@ timerLoop:
 			if conf.DisableHistogramSender {
 				continue
 			}
-			dirEntries, err := os.ReadDir(outboxDir)
+			dirEntries, err := osReadDir(outboxDir)
 			if err != nil {
 				if errors.Is(err, fs.ErrNotExist) {
 					// The directory has not been created yet, this is OK

--- a/pkg/runner/seams.go
+++ b/pkg/runner/seams.go
@@ -27,7 +27,9 @@ var (
 	newFrameStreamSockInput         = dnstap.NewFrameStreamSockInput
 	listenAndServeHTTP              = func(s *http.Server) error { return s.ListenAndServe() }
 	newFileQueue                    = file.New
-	newAutoPahoConnection           = autopaho.NewConnection
+	newAutoPahoConnection           = func(ctx context.Context, cfg autopaho.ClientConfig) (mqttConnectionManager, error) {
+		return autopaho.NewConnection(ctx, cfg)
+	}
 
 	// Filesystem operation seams. These wrap the matching os package
 	// functions so tests can inject failures into the file writers,

--- a/pkg/runner/seams.go
+++ b/pkg/runner/seams.go
@@ -40,9 +40,6 @@ var (
 	osReadDir  = os.ReadDir
 	osStat     = os.Stat
 
-	newAutoPahoConnection           = func(ctx context.Context, cfg autopaho.ClientConfig) (mqttConnectionManager, error) {
-		return autopaho.NewConnection(ctx, cfg)
-	}
 	now                     = time.Now
 	sleep                   = time.Sleep
 	configUpdateDebounce    = 100 * time.Millisecond

--- a/pkg/runner/seams.go
+++ b/pkg/runner/seams.go
@@ -27,12 +27,24 @@ var (
 	listenAndServeHTTP              = func(s *http.Server) error { return s.ListenAndServe() }
 	newFileQueue                    = file.New
 	newAutoPahoConnection           = autopaho.NewConnection
-	now                             = time.Now
-	sleep                           = time.Sleep
-	configUpdateDebounce            = 100 * time.Millisecond
-	fsEventDebounce                 = 100 * time.Millisecond
-	diskCleanerInterval             = time.Minute
-	monitorChannelInterval          = time.Second
-	histogramSenderInterval         = 10 * time.Second
-	histogramSenderBackoff          = 15 * time.Second
+
+	// Filesystem operation seams. These wrap the matching os package
+	// functions so tests can inject failures into the file writers,
+	// renamers and directory scanners without contorting the real
+	// filesystem.
+	osCreate   = os.Create
+	osRename   = os.Rename
+	osRemove   = os.Remove
+	osMkdirAll = os.MkdirAll
+	osReadDir  = os.ReadDir
+	osStat     = os.Stat
+
+	now                     = time.Now
+	sleep                   = time.Sleep
+	configUpdateDebounce    = 100 * time.Millisecond
+	fsEventDebounce         = 100 * time.Millisecond
+	diskCleanerInterval     = time.Minute
+	monitorChannelInterval  = time.Second
+	histogramSenderInterval = 10 * time.Second
+	histogramSenderBackoff  = 15 * time.Second
 )


### PR DESCRIPTION
## What

Stage 3 of the staged coverage effort.

- Add filesystem seams to `seams.go`: `osCreate`, `osRename`, `osRemove`, `osMkdirAll`, `osReadDir`, `osStat` (each wraps the matching `os` function).
- Route the file writers, renamer and directory scanners through them: `createFile`, `renameFile`, `createSessionFile`/`createHistogramFile` cleanup, `diskCleaner`, `histogramSender`. (`setupMQTT`'s `MkdirAll` is intentionally left to its own change to avoid overlap.)

This is a mechanical, behavior-preserving refactor: each seam defaults to the real `os` function. It unblocks injecting filesystem failures in tests — used here for the writers, and by the upcoming `writeRotatedParquet` (stage 4) and `diskCleaner`/`histogramSender` (stage 9) test work.

## Tests

New `pkg/runner/fileops_test.go`:
- `TestCreateFile` — missing-parent-dir retry, mkdir failure, non-ENOENT create error.
- `TestRenameFile` — missing-dest-dir retry, dir-exists-but-rename-fails, stat error, mkdir failure, non-ENOENT rename error.
- `TestSessionWriterLogsCreateError` / `TestHistogramWriterLogsCreateError` — the worker error-log branch (failure injected via `osCreate`).

## Coverage

- `createFile` 91.7% → **100%**, `renameFile` 80% → **100%**, `sessionWriter`/`histogramWriter` 57.1% → **100%**.
- `pkg/runner` 77.4% → 78.3%.

## Verification

`go test -race ./pkg/runner/` green (existing tests unchanged); `golangci-lint run ./pkg/runner/` reports 0 issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for file-operation error handling, retries, and worker error-logging to ensure robust behavior under filesystem failures.

* **Refactor**
  * Replaced direct filesystem calls with abstraction layers for directory and file operations to improve maintainability and testability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->