### PR TITLE
test(runner): make TestRunMinimiserFlows reload deterministic (fix flaky CI)

### DIFF
--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -1338,6 +1338,13 @@ func TestRunMinimiserFlows(t *testing.T) {
 	}
 
 	edm.conf.DisableSessionFiles = true
+	// Signal a config reload, then send it a second time. The reload channel
+	// has capacity 1, so the second send blocks until runMinimiser has
+	// received (and therefore applied) the first, guaranteeing the
+	// disabled-session config is in effect before we feed the next frame.
+	// Without this, runMinimiser's select could pick the buffered input frame
+	// before the buffered reload and emit a session with the stale config.
+	edm.reloadMinimiserConfigCh[0] <- struct{}{}
 	edm.reloadMinimiserConfigCh[0] <- struct{}{}
 	edm.inputChannel <- newFrame
 	time.Sleep(20 * time.Millisecond)


### PR DESCRIPTION
## Problem

`TestRunMinimiserFlows` intermittently fails CI under `go test -race ./...` with:

```
runner_extra_test.go: unexpected session while disabled: &runner.sessionData{...}
```

(e.g. https://github.com/dnstapir/edm/actions/runs/26752368631/job/78843361943)

## Root cause

The test sets `DisableSessionFiles = true`, signals a reload on `reloadMinimiserConfigCh[0]`, then immediately feeds a frame on `inputChannel`. Both channels are buffered, so when the worker is mid-processing as both arrive, `runMinimiser`'s `select` (runner.go:1957) can pick the **input frame before the reload** — Go selects randomly among ready cases — and emit a session using the stale (sessions-enabled) cached config (runner.go:2049). On idle machines the worker usually consumes the reload first, which is why it only flakes under CI load.

This is a test-determinism bug, not a production issue: at runtime, config reloads are intentionally eventually-consistent.

## Fix

Send the reload **twice**. The reload channel has capacity 1, so the second send blocks until the worker has received (and thus applied) the first reload, guaranteeing `DisableSessionFiles` is in effect before the next frame is processed — regardless of `select` ordering. No production change.

## Verification

- `go test -race -count=60 ./pkg/runner/ -run TestRunMinimiserFlows`
- `go test -cpu=1 -count=100 ./pkg/runner/ -run TestRunMinimiserFlows`
- full `go test -race ./pkg/runner/` + `golangci-lint run` — all clean.