### PR TITLE
[codex] Build container only on published releases

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,22 +1,12 @@
 name: Build container
 
 on:
-  workflow_run:
-    workflows:
-      - "Build"
-    branches:
-      - "main"
-    types:
-      - completed
   release:
     types:
       - published
 
 jobs:
   tagged-container:
-    if: >-
-      ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
-          (github.event_name == 'release'      && github.event.action == 'published') }}
     name: Build and push container
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Remove the container workflow_run trigger for completed Build runs on main
- Drop the now-redundant job-level event guard so the workflow only runs for published releases

## Validation
- git diff --cached --check
- Ruby YAML parse of .github/workflows/container.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI/CD workflow configuration to improve deployment process efficiency.

**Note:** This change is internal infrastructure-focused and does not impact end-user features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->