### PR TITLE
test(runner): cover writeRotatedParquet branches (coverage stage 4 tests)

### DIFF
--- a/pkg/runner/fileops_test.go
+++ b/pkg/runner/fileops_test.go
@@ -133,6 +133,158 @@ func TestRenameFile(t *testing.T) {
 	})
 }
 
+func TestWriteRotatedParquet(t *testing.T) {
+	t.Run("happy", func(t *testing.T) {
+		edm := discardEDM()
+		dir := t.TempDir()
+		tmp := filepath.Join(dir, "data.tmp")
+		final := filepath.Join(dir, "data")
+
+		name, err := edm.writeRotatedParquet("test", tmp, final, func(w io.Writer) error {
+			_, err := w.Write([]byte("hello"))
+			return err
+		})
+		if err != nil {
+			t.Fatalf("writeRotatedParquet: %v", err)
+		}
+		if name != final {
+			t.Fatalf("name = %q, want %q", name, final)
+		}
+		if _, err := os.Stat(tmp); !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("tmp file should be gone after rename, stat err = %v", err)
+		}
+		data, err := os.ReadFile(final)
+		if err != nil {
+			t.Fatalf("read final: %v", err)
+		}
+		if string(data) != "hello" {
+			t.Fatalf("contents = %q, want %q", string(data), "hello")
+		}
+	})
+
+	t.Run("createFile error", func(t *testing.T) {
+		edm := discardEDM()
+		swapSeam(t, &osCreate, func(string) (*os.File, error) { return nil, errInjected })
+		_, err := edm.writeRotatedParquet("test", filepath.Join(t.TempDir(), "x"), "y", func(io.Writer) error {
+			return nil
+		})
+		if !errors.Is(err, errInjected) {
+			t.Fatalf("error = %v, want %v", err, errInjected)
+		}
+	})
+
+	t.Run("write error removes temp file", func(t *testing.T) {
+		edm := discardEDM()
+		dir := t.TempDir()
+		tmp := filepath.Join(dir, "data.tmp")
+		final := filepath.Join(dir, "data")
+
+		_, err := edm.writeRotatedParquet("test", tmp, final, func(io.Writer) error {
+			return errInjected
+		})
+		if !errors.Is(err, errInjected) {
+			t.Fatalf("error = %v, want %v", err, errInjected)
+		}
+		if _, err := os.Stat(tmp); !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("tmp file should be removed after write error, stat err = %v", err)
+		}
+		if _, err := os.Stat(final); !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("final file should not exist, stat err = %v", err)
+		}
+	})
+
+	t.Run("write error and remove failure is logged", func(t *testing.T) {
+		edm := discardEDM()
+		var buf bytes.Buffer
+		edm.log = slog.New(slog.NewJSONHandler(&buf, nil))
+
+		dir := t.TempDir()
+		tmp := filepath.Join(dir, "data.tmp")
+		final := filepath.Join(dir, "data")
+
+		swapSeam(t, &osRemove, func(string) error { return errInjected })
+
+		_, err := edm.writeRotatedParquet("test", tmp, final, func(io.Writer) error {
+			return errInjected
+		})
+		if !errors.Is(err, errInjected) {
+			t.Fatalf("error = %v, want %v", err, errInjected)
+		}
+		if !strings.Contains(buf.String(), "unable to remove test outFile") {
+			t.Fatalf("expected remove failure log, got: %q", buf.String())
+		}
+	})
+
+	t.Run("explicit Close error after successful write", func(t *testing.T) {
+		edm := discardEDM()
+		dir := t.TempDir()
+		tmp := filepath.Join(dir, "data.tmp")
+		final := filepath.Join(dir, "data")
+
+		// Closing outFile inside the write closure makes the helper's
+		// explicit Close() fail with os.ErrClosed.
+		_, err := edm.writeRotatedParquet("test", tmp, final, func(w io.Writer) error {
+			return w.(*os.File).Close()
+		})
+		if !errors.Is(err, os.ErrClosed) {
+			t.Fatalf("error = %v, want os.ErrClosed", err)
+		}
+		// Close-error path sets writeFailed, so the temp file is removed.
+		if _, err := os.Stat(tmp); !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("tmp file should be removed, stat err = %v", err)
+		}
+	})
+
+	t.Run("deferred Close error is logged", func(t *testing.T) {
+		edm := discardEDM()
+		var buf bytes.Buffer
+		edm.log = slog.New(slog.NewJSONHandler(&buf, nil))
+
+		dir := t.TempDir()
+		tmp := filepath.Join(dir, "data.tmp")
+		final := filepath.Join(dir, "data")
+
+		// Closing outFile inside the write closure AND returning an error
+		// causes the deferred Close() (which only runs when fileOpen=true)
+		// to fail with os.ErrClosed.
+		_, err := edm.writeRotatedParquet("test", tmp, final, func(w io.Writer) error {
+			_ = w.(*os.File).Close()
+			return errInjected
+		})
+		if !errors.Is(err, errInjected) {
+			t.Fatalf("error = %v, want %v", err, errInjected)
+		}
+		if !strings.Contains(buf.String(), "unable to do deferred close of test outFile") {
+			t.Fatalf("expected deferred close failure log, got: %q", buf.String())
+		}
+	})
+
+	t.Run("rename error leaves temp file", func(t *testing.T) {
+		edm := discardEDM()
+		dir := t.TempDir()
+		tmp := filepath.Join(dir, "data.tmp")
+		final := filepath.Join(dir, "data")
+
+		swapSeam(t, &osRename, func(string, string) error { return errInjected })
+
+		_, err := edm.writeRotatedParquet("test", tmp, final, func(w io.Writer) error {
+			_, err := w.Write([]byte("hello"))
+			return err
+		})
+		if !errors.Is(err, errInjected) {
+			t.Fatalf("error = %v, want %v", err, errInjected)
+		}
+		// Rename failure intentionally leaves the temp file in place
+		// (matches the pre-refactor behavior).
+		if _, err := os.Stat(tmp); err != nil {
+			t.Fatalf("tmp file should remain after rename error, stat err = %v", err)
+		}
+		if _, err := os.Stat(final); !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("final file should not exist, stat err = %v", err)
+		}
+	})
+}
+
 // TestSessionWriterLogsCreateError verifies the sessionWriter worker logs and
 // keeps running when createSessionFile fails. The failure is injected via the
 // osCreate seam so writeSessionParquet is never reached.

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -2202,56 +2202,14 @@ func (edm *dnstapMinimiser) createSessionFile(ps *prevSessions, dataDir string) 
 	absoluteTmpFileName, absoluteFileName := buildParquetFilenames(sessionsDir, "dns_session_block", startTime, ps.rotationTime)
 
 	absoluteTmpFileName = filepath.Clean(absoluteTmpFileName) // Make gosec happy
-	edm.log.Info("writing out session parquet file", "filename", absoluteTmpFileName)
 
-	outFile, err := edm.createFile(absoluteTmpFileName)
+	name, err := edm.writeRotatedParquet("session", absoluteTmpFileName, absoluteFileName, func(w io.Writer) error {
+		return edm.writeSessionParquet(w, ps)
+	})
 	if err != nil {
-		return "", fmt.Errorf("createSessionFile: unable to open session file: %w", err)
+		return "", fmt.Errorf("createSessionFile: %w", err)
 	}
-	fileOpen := true
-	writeFailed := false
-	defer func() {
-		// Closing a *os.File twice returns an error, so only do it if
-		// we have not already tried to close it.
-		if fileOpen {
-			err := outFile.Close()
-			if err != nil {
-				edm.log.Error("createSessionFile: unable to do deferred close of session outFile", "error", err)
-			}
-		}
-		if writeFailed {
-			edm.log.Info("createSessionFile: cleaning up file because write failed", "filename", outFile.Name())
-			err = osRemove(outFile.Name())
-			if err != nil {
-				edm.log.Error("createSessionFile: unable to remove session outFile", "error", err, "filename", outFile.Name())
-			}
-		}
-	}()
-
-	err = edm.writeSessionParquet(outFile, ps)
-	if err != nil {
-		writeFailed = true
-		edm.log.Error("sessionWriter", "error", err.Error())
-		return "", fmt.Errorf("createSessionFile: writing parquet data failed: %w", err)
-	}
-
-	// We need to close the file before renaming it
-	err = outFile.Close()
-	// at this point we do not want the defer to close the file for us when returning
-	fileOpen = false
-	if err != nil {
-		writeFailed = true
-		return "", fmt.Errorf("createSessionFile: unable to call Close() on parquet writer: %w", err)
-	}
-
-	// Atomically rename the file to its real name so it can be picked up by the histogram sender
-	edm.log.Info("renaming session file", "from", absoluteTmpFileName, "to", absoluteFileName)
-	err = osRename(absoluteTmpFileName, absoluteFileName)
-	if err != nil {
-		return "", fmt.Errorf("createSessionFile: unable to rename output file: %w", err)
-	}
-
-	return absoluteFileName, nil
+	return name, nil
 }
 
 func (edm *dnstapMinimiser) sessionWriter(dataDir string, wg *sync.WaitGroup) {
@@ -2274,12 +2232,27 @@ func (edm *dnstapMinimiser) createHistogramFile(prevWellKnownDomainsData *wellKn
 
 	absoluteTmpFileName, absoluteFileName := buildParquetFilenames(outboxDir, "dns_histogram", startTime, prevWellKnownDomainsData.rotationTime)
 
-	edm.log.Info("writing out histogram file", "filename", absoluteTmpFileName)
-
 	absoluteTmpFileName = filepath.Clean(absoluteTmpFileName)
-	outFile, err := edm.createFile(absoluteTmpFileName)
+
+	name, err := edm.writeRotatedParquet("histogram", absoluteTmpFileName, absoluteFileName, func(w io.Writer) error {
+		return edm.writeHistogramParquet(w, startTime, prevWellKnownDomainsData, labelLimit)
+	})
 	if err != nil {
-		return "", fmt.Errorf("createHistogramFile: unable to open histogram file: %w", err)
+		return "", fmt.Errorf("createHistogramFile: %w", err)
+	}
+	return name, nil
+}
+
+// writeRotatedParquet creates tmpName via createFile, invokes write to populate
+// it, then atomically renames it to finalName. On any failure between create
+// and rename the temp file is removed. label disambiguates concurrent rotations
+// in log lines (e.g. "session" or "histogram"). Returns finalName on success.
+func (edm *dnstapMinimiser) writeRotatedParquet(label, tmpName, finalName string, write func(io.Writer) error) (string, error) {
+	edm.log.Info("writing out "+label+" file", "filename", tmpName)
+
+	outFile, err := edm.createFile(tmpName)
+	if err != nil {
+		return "", fmt.Errorf("unable to open %s file: %w", label, err)
 	}
 	fileOpen := true
 	writeFailed := false
@@ -2287,44 +2260,38 @@ func (edm *dnstapMinimiser) createHistogramFile(prevWellKnownDomainsData *wellKn
 		// Closing a *os.File twice returns an error, so only do it if
 		// we have not already tried to close it.
 		if fileOpen {
-			err := outFile.Close()
-			if err != nil {
-				edm.log.Error("createHistogramFile: unable to do deferred close of histogram outFile", "error", err)
+			if err := outFile.Close(); err != nil {
+				edm.log.Error("unable to do deferred close of "+label+" outFile", "error", err)
 			}
 		}
 		if writeFailed {
-			edm.log.Info("createHistogramFile: cleaning up file because write failed", "filename", outFile.Name())
-			err = osRemove(outFile.Name())
-			if err != nil {
-				edm.log.Error("createHistogramFile: unable to remove histogram outFile", "error", err, "filename", outFile.Name())
+			edm.log.Info("cleaning up "+label+" file because write failed", "filename", outFile.Name())
+			if err := osRemove(outFile.Name()); err != nil {
+				edm.log.Error("unable to remove "+label+" outFile", "error", err, "filename", outFile.Name())
 			}
 		}
 	}()
 
-	err = edm.writeHistogramParquet(outFile, startTime, prevWellKnownDomainsData, labelLimit)
-	if err != nil {
+	if err := write(outFile); err != nil {
 		writeFailed = true
-		edm.log.Error("histogramWriter", "error", err.Error())
-		return "", fmt.Errorf("createHistogramFile: writing parquet data failed: %w", err)
+		return "", fmt.Errorf("writing parquet data failed: %w", err)
 	}
 
-	// We need to close the file before renaming it
+	// We need to close the file before renaming it.
 	err = outFile.Close()
-	// at this point we do not want the defer to close the file for us when returning
+	// At this point we do not want the defer to close the file for us when returning.
 	fileOpen = false
 	if err != nil {
 		writeFailed = true
-		return "", fmt.Errorf("createHistogramFile: unable to call Close() on file: %w", err)
+		return "", fmt.Errorf("unable to call Close() on file: %w", err)
 	}
 
-	// Atomically rename the file to its real name so it can be picked up by the histogram sender
-	edm.log.Info("renaming histogram file", "from", absoluteTmpFileName, "to", absoluteFileName)
-	err = osRename(absoluteTmpFileName, absoluteFileName)
-	if err != nil {
-		return "", fmt.Errorf("createHistogramFile: unable to rename output file: %w", err)
+	// Atomically rename the file to its real name so it can be picked up downstream.
+	edm.log.Info("renaming "+label+" file", "from", tmpName, "to", finalName)
+	if err := osRename(tmpName, finalName); err != nil {
+		return "", fmt.Errorf("unable to rename output file: %w", err)
 	}
-
-	return absoluteFileName, nil
+	return finalName, nil
 }
 
 func (edm *dnstapMinimiser) histogramWriter(labelLimit int, outboxDir string, wg *sync.WaitGroup) {


### PR DESCRIPTION
## What

The follow-up test PR for [#211](https://github.com/dnstapir/edm/pull/211). Brings the
new `writeRotatedParquet` helper to 100% by covering every branch via the file-op seams
introduced in #208 plus a Close-injection trick that needs no new seams.

**Stacked on #211** — base is `coverage/stage-4-write-rotated-parquet`. Once #211 lands,
the base will retarget to `main` and the diff becomes test-only.

## Cases

- `happy` — file is created, written, renamed; temp gone, final has data
- `createFile error` — `osCreate` seam injection surfaces the error
- `write error removes temp file`
- `write error and remove failure is logged` — covers the defer's `osRemove`-failure branch
- `explicit Close error after successful write` — closure closes `outFile`, so the helper's
  explicit `Close()` hits `os.ErrClosed`, sets `writeFailed=true`, and the defer removes the temp
- `deferred Close error is logged` — closure closes `outFile` **and** returns an error so the
  defer's `Close()` runs against an already-closed handle
- `rename error leaves temp file` — documents preserved behavior

## How the Close-error injection works

Without faking `*os.File` (which would require a new seam), the only way to deterministically
fail `Close` on a healthy real file is to close it ourselves first. The write closure receives
the underlying `*os.File` as `io.Writer` and type-asserts back to call `Close()`. The next
`Close()` call (explicit or deferred) then returns `os.ErrClosed`. The asserts use `errors.Is`
so they survive any future error-chain wrapping.

## Coverage

- `writeRotatedParquet`: 61.5% → **100%**
- `pkg/runner`: 79.5% → **80.1%**

## Verification

`go test -race -count=2 ./pkg/runner/ -run TestWriteRotatedParquet` — all 7 subtests pass;
full `go test -race ./pkg/runner/` green; `golangci-lint run ./...` reports 0 issues.