### PR TITLE
test(runner): cover setupDnstapInput branches (coverage stage 5 tests)

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -272,6 +272,7 @@ type certStore struct {
 var (
 	errNoClientCertificate = errors.New("no client certificate loaded")
 	errEmptyDawgFile       = errors.New("dawg file is empty")
+	errNoInputConfigured   = errors.New("no dnstap input configured")
 )
 
 // Implements tls.Config.GetClientCertificate
@@ -628,6 +629,63 @@ func getHllDefaults(explicitThreshold int) hll.Settings {
 		ExplicitThreshold: explicitThreshold,
 		SparseEnabled:     true,
 	}
+}
+
+// setupDnstapInput constructs the dnstap socket input selected by startConf.
+// Exactly one of InputUnix/InputTCP/InputTLS must be set; with none configured
+// it returns errNoInputConfigured rather than letting Run dereference a nil
+// *FrameStreamSockInput. On TLS, InputTLSClientCAFile (when set) enables
+// required-and-verify client mTLS via tls.RequireAndVerifyClientCert.
+func setupDnstapInput(logger *slog.Logger, startConf config) (*dnstap.FrameStreamSockInput, error) {
+	var dti *dnstap.FrameStreamSockInput
+	switch {
+	case startConf.InputUnix != "":
+		logger.Info("creating dnstap unix socket", "socket", startConf.InputUnix)
+		d, err := newFrameStreamSockInputFromPath(startConf.InputUnix)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create dnstap unix socket: %w", err)
+		}
+		dti = d
+	case startConf.InputTCP != "":
+		logger.Info("creating plaintext dnstap TCP socket", "socket", startConf.InputTCP)
+		l, err := listenNet("tcp", startConf.InputTCP)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create plaintext dnstap TCP socket: %w", err)
+		}
+		dti = newFrameStreamSockInput(l)
+	case startConf.InputTLS != "":
+		logger.Info("creating encrypted dnstap TLS socket", "socket", startConf.InputTLS)
+		dnstapInputCert, err := tls.LoadX509KeyPair(startConf.InputTLSCertFile, startConf.InputTLSKeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("unable to load x509 dnstap listener cert: %w", err)
+		}
+		dnstapTLSConfig := &tls.Config{
+			Certificates: []tls.Certificate{dnstapInputCert},
+			MinVersion:   tls.VersionTLS13,
+		}
+
+		// Enable client mTLS (client cert auth) if a CA file was passed.
+		if startConf.InputTLSClientCAFile != "" {
+			logger.Info("dnstap socket requiring valid client certs", "ca-file", startConf.InputTLSClientCAFile)
+			inputTLSClientCACertPool, err := certPoolFromFile(startConf.InputTLSClientCAFile)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create CA cert pool for '-input-tls-client-ca-file': %w", err)
+			}
+			dnstapTLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
+			dnstapTLSConfig.ClientCAs = inputTLSClientCACertPool
+		}
+
+		l, err := listenTLS("tcp", startConf.InputTLS, dnstapTLSConfig)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create TCP listener: %w", err)
+		}
+		dti = newFrameStreamSockInput(l)
+	default:
+		return nil, errNoInputConfigured
+	}
+	dti.SetTimeout(time.Second * 5)
+	dti.SetLogger(log.Default())
+	return dti, nil
 }
 
 func (edm *dnstapMinimiser) setupHistogramSender() error {
@@ -1230,57 +1288,11 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 
 	go edm.fsEventWatcher()
 
-	// Setup the dnstap.Input, only one at a time is supported.
-	var dti *dnstap.FrameStreamSockInput
-	if startConf.InputUnix != "" {
-		logger.Info("creating dnstap unix socket", "socket", startConf.InputUnix)
-		dti, err = newFrameStreamSockInputFromPath(startConf.InputUnix)
-		if err != nil {
-			logger.Error("unable to create dnstap unix socket", "error", err)
-			exitProcess(1)
-		}
-	} else if startConf.InputTCP != "" {
-		logger.Info("creating plaintext dnstap TCP socket", "socket", startConf.InputTCP)
-		l, err := listenNet("tcp", startConf.InputTCP)
-		if err != nil {
-			logger.Error("unable to create plaintext dnstap TCP socket", "error", err)
-			exitProcess(1)
-		}
-		dti = newFrameStreamSockInput(l)
-	} else if startConf.InputTLS != "" {
-		logger.Info("creating encrypted dnstap TLS socket", "socket", startConf.InputTLS)
-		dnstapInputCert, err := tls.LoadX509KeyPair(startConf.InputTLSCertFile, startConf.InputTLSKeyFile)
-		if err != nil {
-			logger.Error("unable to load x509 dnstap listener cert", "error", err)
-			exitProcess(1)
-		}
-		dnstapTLSConfig := &tls.Config{
-			Certificates: []tls.Certificate{dnstapInputCert},
-			MinVersion:   tls.VersionTLS13,
-		}
-
-		// Enable client mTLS (client cert auth) if a CA file was passed:
-		if startConf.InputTLSClientCAFile != "" {
-			logger.Info("dnstap socket requiring valid client certs", "ca-file", startConf.InputTLSClientCAFile)
-			inputTLSClientCACertPool, err := certPoolFromFile(startConf.InputTLSClientCAFile)
-			if err != nil {
-				logger.Error("failed to create CA cert pool for '-input-tls-client-ca-file': %s", "error", err)
-				exitProcess(1)
-			}
-
-			dnstapTLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
-			dnstapTLSConfig.ClientCAs = inputTLSClientCACertPool
-		}
-
-		l, err := listenTLS("tcp", startConf.InputTLS, dnstapTLSConfig)
-		if err != nil {
-			logger.Error("unable to create TCP listener", "error", err)
-			exitProcess(1)
-		}
-		dti = newFrameStreamSockInput(l)
+	dti, err := setupDnstapInput(logger, startConf)
+	if err != nil {
+		logger.Error("unable to setup dnstap input", "error", err)
+		exitProcess(1)
 	}
-	dti.SetTimeout(time.Second * 5)
-	dti.SetLogger(log.Default())
 
 	// We need to keep track of domains that are not on the well-known
 	// domain list yet we have seen since we started. To limit the

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -17,6 +17,7 @@ import (
 	"log/slog"
 	"math"
 	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
@@ -1194,6 +1195,130 @@ func TestSetupMQTT(t *testing.T) {
 		err := edm.setupMQTT()
 		if !errors.Is(err, errConnect) {
 			t.Fatalf("setupMQTT error = %v, want %v", err, errConnect)
+		}
+	})
+}
+
+func TestSetupDnstapInput(t *testing.T) {
+	discardLog := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("no input configured", func(t *testing.T) {
+		_, err := setupDnstapInput(discardLog, config{})
+		if !errors.Is(err, errNoInputConfigured) {
+			t.Fatalf("err = %v, want errNoInputConfigured", err)
+		}
+	})
+
+	t.Run("unix happy", func(t *testing.T) {
+		dti, err := setupDnstapInput(discardLog, config{
+			InputUnix: filepath.Join(t.TempDir(), "dnstap.sock"),
+		})
+		if err != nil {
+			t.Fatalf("setupDnstapInput: %v", err)
+		}
+		if dti == nil {
+			t.Fatal("dti is nil on success")
+		}
+	})
+
+	t.Run("unix error", func(t *testing.T) {
+		swapSeam(t, &newFrameStreamSockInputFromPath, func(string) (*dnstap.FrameStreamSockInput, error) {
+			return nil, errInjected
+		})
+		_, err := setupDnstapInput(discardLog, config{InputUnix: "/tmp/x"})
+		if !errors.Is(err, errInjected) {
+			t.Fatalf("err = %v, want errInjected", err)
+		}
+	})
+
+	t.Run("tcp happy", func(t *testing.T) {
+		dti, err := setupDnstapInput(discardLog, config{InputTCP: "127.0.0.1:0"})
+		if err != nil {
+			t.Fatalf("setupDnstapInput: %v", err)
+		}
+		if dti == nil {
+			t.Fatal("dti is nil on success")
+		}
+	})
+
+	t.Run("tcp listen error", func(t *testing.T) {
+		swapSeam(t, &listenNet, func(string, string) (net.Listener, error) {
+			return nil, errInjected
+		})
+		_, err := setupDnstapInput(discardLog, config{InputTCP: "127.0.0.1:0"})
+		if !errors.Is(err, errInjected) {
+			t.Fatalf("err = %v, want errInjected", err)
+		}
+	})
+
+	t.Run("tls happy", func(t *testing.T) {
+		certPath, keyPath, _ := testCertFiles(t)
+		dti, err := setupDnstapInput(discardLog, config{
+			InputTLS:         "127.0.0.1:0",
+			InputTLSCertFile: certPath,
+			InputTLSKeyFile:  keyPath,
+		})
+		if err != nil {
+			t.Fatalf("setupDnstapInput: %v", err)
+		}
+		if dti == nil {
+			t.Fatal("dti is nil on success")
+		}
+	})
+
+	t.Run("tls happy with client CA", func(t *testing.T) {
+		certPath, keyPath, caPath := testCertFiles(t)
+		dti, err := setupDnstapInput(discardLog, config{
+			InputTLS:             "127.0.0.1:0",
+			InputTLSCertFile:     certPath,
+			InputTLSKeyFile:      keyPath,
+			InputTLSClientCAFile: caPath,
+		})
+		if err != nil {
+			t.Fatalf("setupDnstapInput: %v", err)
+		}
+		if dti == nil {
+			t.Fatal("dti is nil on success")
+		}
+	})
+
+	t.Run("tls bad cert", func(t *testing.T) {
+		_, err := setupDnstapInput(discardLog, config{
+			InputTLS:         "127.0.0.1:0",
+			InputTLSCertFile: filepath.Join(t.TempDir(), "missing.crt"),
+			InputTLSKeyFile:  filepath.Join(t.TempDir(), "missing.key"),
+		})
+		if err == nil || !strings.Contains(err.Error(), "x509 dnstap listener cert") {
+			t.Fatalf("err = %v, want x509 cert load failure", err)
+		}
+	})
+
+	t.Run("tls bad client CA file", func(t *testing.T) {
+		certPath, keyPath, _ := testCertFiles(t)
+		badCA := writeTempFile(t, "bad-ca.pem", []byte("not a pem"))
+		_, err := setupDnstapInput(discardLog, config{
+			InputTLS:             "127.0.0.1:0",
+			InputTLSCertFile:     certPath,
+			InputTLSKeyFile:      keyPath,
+			InputTLSClientCAFile: badCA,
+		})
+		if err == nil || !strings.Contains(err.Error(), "CA cert pool") {
+			t.Fatalf("err = %v, want CA cert pool failure", err)
+		}
+	})
+
+	t.Run("tls listen error", func(t *testing.T) {
+		certPath, keyPath, _ := testCertFiles(t)
+		swapSeam(t, &listenTLS, func(string, string, *tls.Config) (net.Listener, error) {
+			return nil, errInjected
+		})
+		_, err := setupDnstapInput(discardLog, config{
+			InputTLS:         "127.0.0.1:0",
+			InputTLSCertFile: certPath,
+			InputTLSKeyFile:  keyPath,
+		})
+		if !errors.Is(err, errInjected) {
+			t.Fatalf("err = %v, want errInjected", err)
 		}
 	})
 }


### PR DESCRIPTION
## What

Follow-up test PR for [#213](https://github.com/dnstapir/edm/pull/213). Brings the new
`setupDnstapInput` helper to 100% via a 10-row table covering every transport branch
and error path.

**Stacked on #213** — base is `coverage/stage-5-setup-dnstap-input`. Once #213 lands,
this PR's base auto-retargets to `main` and the diff becomes test-only.

## Cases

- `no input configured` → `errNoInputConfigured`
- `unix happy` (real `newFrameStreamSockInputFromPath` against a `t.TempDir` path)
- `unix error` — `newFrameStreamSockInputFromPath` seam returns `errInjected`
- `tcp happy` (real `listenNet` on `127.0.0.1:0`)
- `tcp listenNet error`
- `tls happy` (`testCertFiles` cert+key, ephemeral port)
- `tls happy with client CA` (mTLS branch)
- `tls bad cert` — missing cert/key file paths → `LoadX509KeyPair` error
- `tls bad client CA file` — valid cert, malformed CA pem → `certPoolFromFile` error
- `tls listen error` — `listenTLS` seam returns `errInjected`

Reuses `testCertFiles` for the self-signed cert+CA, `writeTempFile` for the
malformed-pem file, and `swapSeam` (from `fileops_test.go`) for error injection.

## Coverage

- `setupDnstapInput`: 28.1% → **100%**
- `pkg/runner`: 79.0% → **80.5%**

## Verification

`go test -race -count=1 ./pkg/runner/ -run TestSetupDnstapInput -v` — all 10 subtests pass;
full `go test -race ./pkg/runner/` green; `golangci-lint run ./...` reports 0 issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for DNS tap input setup functionality, including validation of error handling, Unix socket, TCP, and TLS listener configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->