### PR TITLE
refactor+test(runner): extract HTTP server builders (coverage stage 6)

### DIFF
--- a/pkg/runner/http_server_test.go
+++ b/pkg/runner/http_server_test.go
@@ -1,0 +1,71 @@
+package runner
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewPprofServer(t *testing.T) {
+	s := newPprofServer("127.0.0.1:0")
+	if s.Addr != "127.0.0.1:0" {
+		t.Fatalf("Addr = %q, want 127.0.0.1:0", s.Addr)
+	}
+	if s.ReadTimeout == 0 || s.WriteTimeout == 0 {
+		t.Fatalf("timeouts not set: read=%s write=%s", s.ReadTimeout, s.WriteTimeout)
+	}
+	// pprof handlers live on http.DefaultServeMux via the blank import; the
+	// server's nil Handler picks DefaultServeMux up at request time, so check
+	// one of the well-known pprof routes resolves to a real handler.
+	req := httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
+	rec := httptest.NewRecorder()
+	http.DefaultServeMux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/debug/pprof/ status = %d, want 200", rec.Code)
+	}
+}
+
+func TestNewMetricsServer(t *testing.T) {
+	t.Run("metrics endpoint responds", func(t *testing.T) {
+		edm := newTestDnstapMinimiser(t, defaultTC)
+		s := edm.newMetricsServer("127.0.0.1:0", false)
+		req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+		rec := httptest.NewRecorder()
+		s.Handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("/metrics status = %d, want 200", rec.Code)
+		}
+		// The promhttp InstrumentMetricHandler registers its own counter
+		// against edm.promReg, so its name always appears in /metrics output
+		// regardless of which other collectors are active.
+		if !strings.Contains(rec.Body.String(), "promhttp_metric_handler_requests_total") {
+			t.Fatalf("/metrics body lacks prometheus output: %q", rec.Body.String())
+		}
+	})
+
+	t.Run("rotate-parquet absent when disabled", func(t *testing.T) {
+		edm := newTestDnstapMinimiser(t, defaultTC)
+		s := edm.newMetricsServer("127.0.0.1:0", false)
+		req := httptest.NewRequest(http.MethodPost, "/debug/rotate-parquet", nil)
+		rec := httptest.NewRecorder()
+		s.Handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("/debug/rotate-parquet status = %d, want 404 when disabled", rec.Code)
+		}
+	})
+
+	t.Run("rotate-parquet present when enabled", func(t *testing.T) {
+		edm := newTestDnstapMinimiser(t, defaultTC)
+		s := edm.newMetricsServer("127.0.0.1:0", true)
+		// A GET should be rejected with 405 by manualParquetRotationHandler's
+		// method-check, proving the route is wired without involving the
+		// (unstarted) rotation worker that a POST would block on.
+		req := httptest.NewRequest(http.MethodGet, "/debug/rotate-parquet", nil)
+		rec := httptest.NewRecorder()
+		s.Handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("/debug/rotate-parquet status = %d, want 405 when enabled", rec.Code)
+		}
+	})
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1133,6 +1133,37 @@ func (edm *dnstapMinimiser) getConfig() config {
 	return conf
 }
 
+// newPprofServer constructs the pprof HTTP server that serves net/http/pprof
+// from the default mux (the package's init() registers the handlers on import).
+// Address is parameterised so tests can listen on an ephemeral port.
+func newPprofServer(addr string) *http.Server {
+	return &http.Server{
+		Addr:         addr,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 31 * time.Second,
+	}
+}
+
+// newMetricsServer constructs the metrics HTTP server: /metrics is wired
+// against edm.promReg, and /debug/rotate-parquet is registered only when
+// enableManualRotation is true. Address is parameterised so tests can
+// listen on an ephemeral port.
+func (edm *dnstapMinimiser) newMetricsServer(addr string, enableManualRotation bool) *http.Server {
+	mux := http.NewServeMux()
+	// Setup custom promHandler since we want to use our per-edm registry.
+	mux.Handle("/metrics", promhttp.InstrumentMetricHandler(edm.promReg, promhttp.HandlerFor(edm.promReg, promhttp.HandlerOpts{Registry: edm.promReg})))
+	if enableManualRotation {
+		mux.HandleFunc("/debug/rotate-parquet", edm.manualParquetRotationHandler)
+	}
+	return &http.Server{
+		Addr:           addr,
+		Handler:        mux,
+		ReadTimeout:    10 * time.Second,
+		WriteTimeout:   metricsServerWriteTimeout,
+		MaxHeaderBytes: 1 << 20,
+	}
+}
+
 func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 	// Create an instance of the minimiser
 	vc := viperConfiger{}
@@ -1292,32 +1323,13 @@ func Run(logger *slog.Logger, loggerLevel *slog.LevelVar) {
 		exitProcess(1)
 	}
 
-	// Uses the default mux which is modified by importing net/http/pprof
-	pprofServer := &http.Server{
-		Addr:         "127.0.0.1:6060",
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 31 * time.Second,
-	}
-
+	pprofServer := newPprofServer(pprofListenAddr)
 	go func() {
 		err := listenAndServeHTTP(pprofServer)
 		logger.Error("pprofServer failed", "error", err)
 	}()
 
-	metricsMux := http.NewServeMux()
-	metricsServer := &http.Server{
-		Addr:           "127.0.0.1:2112",
-		Handler:        metricsMux,
-		ReadTimeout:    10 * time.Second,
-		WriteTimeout:   metricsServerWriteTimeout,
-		MaxHeaderBytes: 1 << 20,
-	}
-
-	// Setup custom promHandler since we want to use our per-edm registry
-	metricsMux.Handle("/metrics", promhttp.InstrumentMetricHandler(edm.promReg, promhttp.HandlerFor(edm.promReg, promhttp.HandlerOpts{Registry: edm.promReg})))
-	if startConf.EnableManualParquetRotation {
-		metricsMux.HandleFunc("/debug/rotate-parquet", edm.manualParquetRotationHandler)
-	}
+	metricsServer := edm.newMetricsServer(metricsListenAddr, startConf.EnableManualParquetRotation)
 	go func() {
 		err := listenAndServeHTTP(metricsServer)
 		logger.Error("metricsServer failed", "error", err)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -65,6 +65,10 @@ const defaultLabelLimit = 10
 const (
 	metricsServerWriteTimeout        = 10 * time.Second
 	manualParquetRotationWaitTimeout = metricsServerWriteTimeout - time.Second
+	// pprofWriteTimeout has to outlast a full pprof profile, whose default
+	// `seconds` parameter is 30 — anything shorter would truncate the
+	// default CPU profile.
+	pprofWriteTimeout = 31 * time.Second
 )
 
 type config struct {
@@ -1140,7 +1144,7 @@ func newPprofServer(addr string) *http.Server {
 	return &http.Server{
 		Addr:         addr,
 		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 31 * time.Second,
+		WriteTimeout: pprofWriteTimeout,
 	}
 }
 

--- a/pkg/runner/seams.go
+++ b/pkg/runner/seams.go
@@ -50,4 +50,9 @@ var (
 	monitorChannelInterval  = time.Second
 	histogramSenderInterval = 10 * time.Second
 	histogramSenderBackoff  = 15 * time.Second
+
+	// HTTP listen addresses for the pprof and metrics servers. These are
+	// seams so tests can swap them for ephemeral ports.
+	pprofListenAddr   = "127.0.0.1:6060"
+	metricsListenAddr = "127.0.0.1:2112"
 )


### PR DESCRIPTION
## What

Stage 6 of the staged coverage effort — combined refactor + tests per the plan.

Lifts the inline \`http.Server\` construction for the pprof and metrics servers (~30 lines
of \`Run\`) into dedicated builders:

\`\`\`go
func newPprofServer(addr string) *http.Server
func (edm *dnstapMinimiser) newMetricsServer(addr string, enableManualRotation bool) *http.Server
\`\`\`

Adds \`pprofListenAddr\` / \`metricsListenAddr\` seam vars defaulting to today's literals
(\`127.0.0.1:6060\` / \`127.0.0.1:2112\`) so the upcoming \`run()\` test PR (stage 8) can swap
them for ephemeral ports without colliding between parallel test cases. \`Run\` keeps the two
\`go listenAndServeHTTP(...)\` launches against the values returned by the builders.

## Tests

- **TestNewPprofServer** — fields/timeouts set; \`/debug/pprof/\` resolves on
  \`http.DefaultServeMux\` (the blank \`net/http/pprof\` import registers it).
- **TestNewMetricsServer**
  - \`/metrics\` responds with prometheus output (checks the always-present
    \`promhttp_metric_handler_requests_total\` counter so the assertion doesn't depend on
    which other collectors are wired).
  - \`/debug/rotate-parquet\` returns 404 when \`enableManualRotation=false\`.
  - \`/debug/rotate-parquet\` returns 405-on-GET when \`enableManualRotation=true\` —
    proving the route is wired without engaging the unstarted rotation worker that a
    POST would block on.

## Coverage

- \`newPprofServer\`: 100%
- \`newMetricsServer\`: 100%
- \`pkg/runner\`: 78.3% → **80.3%**

## Verification

\`go test -race ./pkg/runner/\` green; \`golangci-lint run ./...\` reports 0 issues;
\`gofmt -l\` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests for HTTP server configuration and endpoints.

* **Refactor**
  * Restructured HTTP server initialization code for improved organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->