### PR TITLE
refactor(runner): widen testConfiger and move to _test.go (coverage stage 7)

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1119,26 +1119,6 @@ type edmConfiger interface {
 	getConfig() (config, error)
 }
 
-type testConfiger struct {
-	CryptopanKey            string
-	CryptopanKeySalt        string
-	CryptopanAddressEntries int
-	Debug                   bool
-	DisableHistogramSender  bool
-	DisableMQTT             bool
-}
-
-func (tc testConfiger) getConfig() (config, error) {
-	return config{
-		CryptopanKey:            tc.CryptopanKey,
-		CryptopanKeySalt:        tc.CryptopanKeySalt,
-		CryptopanAddressEntries: tc.CryptopanAddressEntries,
-		Debug:                   tc.Debug,
-		DisableHistogramSender:  tc.DisableHistogramSender,
-		DisableMQTT:             tc.DisableMQTT,
-	}, nil
-}
-
 type viperConfiger struct{}
 
 func (vc viperConfiger) getConfig() (config, error) {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -28,15 +28,66 @@ import (
 var (
 	testDawg     = flag.Bool("test-dawg", false, "perform tests requiring a well-known-domains.dawg file")
 	writeParquet = flag.Bool("write-parquet", false, "make parquet tests write out files in a temporary directory")
-	defaultTC    = testConfiger{
-		CryptopanKey:            "key1",
-		CryptopanKeySalt:        "aabbccddeeffgghh",
-		CryptopanAddressEntries: 10,
-		Debug:                   false,
-		DisableHistogramSender:  false,
-		DisableMQTT:             false,
-	}
+	defaultTC    = newDefaultTC()
 )
+
+// testConfiger is an edmConfiger backed by a complete config value. Tests
+// build on defaultTestConfig (which mirrors pkg/cmd/run.go's flag defaults)
+// and override individual fields rather than going through the viper
+// unmarshaling pipeline. Embedding config promotes every field so a test
+// can do `tc := defaultTC; tc.MQTTServer = "..."` directly.
+//
+// testConfiger is test-only; production wires viperConfiger.
+type testConfiger struct {
+	config
+}
+
+// getConfig implements edmConfiger.
+func (tc testConfiger) getConfig() (config, error) {
+	return tc.config, nil
+}
+
+// defaultTestConfig returns a config populated with pkg/cmd/run.go's flag
+// defaults for the scalar/path fields. URL- and address-typed fields
+// (MQTTServer, HTTPURL) are deliberately left empty because run.go's
+// defaults (`127.0.0.1:8883`, etc.) are bare host:port values that fail
+// `url.Parse` for autopaho/HTTP — those defaults are only useful once a
+// scheme is added at the CLI layer, so tests must opt in by setting them.
+//
+// testConfiger does not run validate.Struct, so the missing required_*
+// tags do not block construction.
+func defaultTestConfig() config {
+	return config{
+		ConfigFile:                    "edm.toml",
+		WellKnownDomainsFile:          "well-known-domains.dawg",
+		DataDir:                       "/var/lib/dnstapir/edm",
+		MinimiserWorkers:              1,
+		CryptopanKeySalt:              "edm-kdf-salt-val",
+		QnameSeenEntries:              10_000_000,
+		CryptopanAddressEntries:       10_000_000,
+		NewQnameBuffer:                1000,
+		HistogramHLLExplicitThreshold: 20,
+		MQTTSigningKeyFile:            "edm-mqtt-signer-key.pem",
+		MQTTClientKeyFile:             "edm-mqtt-client-key.pem",
+		MQTTClientCertFile:            "edm-mqtt-client.pem",
+		MQTTKeepalive:                 30,
+		HTTPSigningKeyFile:            "edm-http-signer-key.pem",
+		HTTPClientKeyFile:             "edm-http-client-key.pem",
+		HTTPClientCertFile:            "edm-http-client.pem",
+	}
+}
+
+// newDefaultTC builds the testConfiger used by most tests. It starts from
+// defaultTestConfig and overrides the cryptopan fields with values the
+// surrounding tests assume (a short key and a tiny LRU so cache-eviction
+// branches are reachable without millions of entries).
+func newDefaultTC() testConfiger {
+	c := defaultTestConfig()
+	c.CryptopanKey = "key1"
+	c.CryptopanKeySalt = "aabbccddeeffgghh"
+	c.CryptopanAddressEntries = 10
+	return testConfiger{config: c}
+}
 
 func newTestDnstapMinimiser(t testing.TB, tc testConfiger) *dnstapMinimiser {
 	t.Helper()


### PR DESCRIPTION
## What

Stage 7 of the staged coverage effort — a test-infra refactor that unblocks the upcoming
\`run()\` core tests in stage 8.

\`testConfiger\` and its \`getConfig\` method were test-only code shipped in the production
binary, with only 6 of ~40 \`config\` fields wired through — forcing tests that need
fields beyond cryptopan/disable-toggles to take the heavyweight viper-TOML route through
\`TestRunWithDisabledSenders\`.

This PR moves the type to \`runner_test.go\` (where \`defaultTC\` already lives) and
re-backs it by an embedded \`config\` value with \`pkg/cmd/run.go\`-style defaults:

- \`testConfiger\` now embeds \`config\`; tests can set any of the ~40 fields via field
  promotion (\`tc := defaultTC; tc.MQTTSigningKeyFile = "..."\`).
- \`defaultTestConfig()\` returns a \`config\` populated with run.go's scalar/path flag
  defaults. \`MQTTServer\` and \`HTTPURL\` are intentionally left empty: run.go's defaults
  are bare \`host:port\` values that fail \`url.Parse\` — those defaults are only valid
  once a scheme is added at the CLI layer, so tests opt in by setting them explicitly.
- \`defaultTC = newDefaultTC()\` overrides \`CryptopanKey\`/\`Salt\` and shrinks
  \`CryptopanAddressEntries\` to 10, matching the prior \`testConfiger\` literal.

## Verification

- \`grep -rn testConfiger\|defaultTestConfig\|newDefaultTC pkg/ --include='*.go'\` finds
  zero references outside \`_test.go\` files — production binary is free of test-only code.
- \`TestRunWithDisabledSenders\` (the canary) passes unchanged.
- Full \`go test -race ./pkg/runner/\` green; \`golangci-lint run ./...\` reports 0 issues.

## Coverage

- \`pkg/runner\`: 80.5% → **82.0%**

Coverage rises mechanically because production code shrinks by 20 lines while existing
test reach stays constant; no new test cases were added (this is a test-infra PR per the plan).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to configuration handling and testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->