### PR TITLE
test(runner): cover run() error paths (coverage stage 8b)

### DIFF
--- a/pkg/runner/run_core_test.go
+++ b/pkg/runner/run_core_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/pebble"
 	"github.com/spf13/viper"
@@ -47,15 +48,37 @@ func discardLogger() *slog.Logger {
 }
 
 // pinHTTPServersToEphemeral overrides the pprof/metrics listen-addr seams
-// to ephemeral ports plus a listenAndServeHTTP that exits immediately, so
-// parallel tests do not collide on :6060/:2112 and the two server
+// to ephemeral ports plus a listenAndServeHTTP stub that exits immediately,
+// so parallel tests do not collide on :6060/:2112 and the two server
 // goroutines never actually bind a port.
+//
+// The stub also signals via a buffered channel each time it is called so
+// the test can wait for both spawned goroutines to finish reading
+// listenAndServeHTTP before swapSeam's restoration runs — without that
+// happens-before edge, the race detector flags the goroutine's read
+// against the cleanup's write.
 func pinHTTPServersToEphemeral(t *testing.T) {
 	t.Helper()
 	swapSeam(t, &pprofListenAddr, "127.0.0.1:0")
 	swapSeam(t, &metricsListenAddr, "127.0.0.1:0")
+	exited := make(chan struct{}, 2)
 	swapSeam(t, &listenAndServeHTTP, func(*http.Server) error {
+		exited <- struct{}{}
 		return http.ErrServerClosed
+	})
+	t.Cleanup(func() {
+		// LIFO order means this runs before swapSeam's listenAndServeHTTP
+		// restore, so the read-then-write race is closed when both goroutines
+		// have signalled. A subtest that returned before pprof/metrics spawned
+		// (e.g. an early-error case) sends nothing; the short timeout keeps
+		// the cleanup snappy in that case.
+		for range 2 {
+			select {
+			case <-exited:
+			case <-time.After(time.Second):
+				return
+			}
+		}
 	})
 }
 
@@ -95,19 +118,41 @@ func TestRunCore_ErrorPaths(t *testing.T) {
 		}
 	})
 
-	t.Run("setupHistogramSender error", func(t *testing.T) {
+	t.Run("histogram sender enabled: loadHTTPClientCert error", func(t *testing.T) {
+		// This test exercises the histogram-sender-enabled prefix: with
+		// DisableHistogramSender=false, run() calls loadHTTPClientCert
+		// before setupHistogramSender. Missing cert/key paths trip
+		// loadHTTPClientCert, so the returned error is the
+		// "HTTP client cert" wrap — setupHistogramSender itself never
+		// runs. The test name and assertion reflect that.
 		runCoreCleanup(t)
 		tc := runCoreTC(t)
 		tc.DisableHistogramSender = false
-		// Missing cert/key files trip loadHTTPClientCert before
-		// setupHistogramSender; either way the error chain wraps "HTTP
-		// client cert" or "histogram sender".
 		tc.HTTPClientCertFile = filepath.Join(t.TempDir(), "missing.crt")
 		tc.HTTPClientKeyFile = filepath.Join(t.TempDir(), "missing.key")
 		edm := newTestDnstapMinimiser(t, tc)
 		err := run(edm, discardLogger(), new(slog.LevelVar))
 		if err == nil || !strings.Contains(err.Error(), "HTTP client cert") {
 			t.Fatalf("err = %v, want HTTP-client-cert failure", err)
+		}
+	})
+
+	t.Run("setupHistogramSender error", func(t *testing.T) {
+		// Real matching cert+key so loadHTTPClientCert succeeds and the
+		// failure surfaces from setupHistogramSender itself (here via an
+		// unparseable HTTPURL).
+		runCoreCleanup(t)
+		tc := runCoreTC(t)
+		tc.DisableHistogramSender = false
+		certPath, keyPath, _ := testCertFiles(t)
+		tc.HTTPClientCertFile = certPath
+		tc.HTTPClientKeyFile = keyPath
+		tc.HTTPURL = "://bad-url"
+		edm := newTestDnstapMinimiser(t, tc)
+		err := run(edm, discardLogger(), new(slog.LevelVar))
+		if err == nil ||
+			!strings.Contains(err.Error(), "histogram sender") {
+			t.Fatalf("err = %v, want histogram-sender failure", err)
 		}
 	})
 

--- a/pkg/runner/run_core_test.go
+++ b/pkg/runner/run_core_test.go
@@ -1,0 +1,179 @@
+package runner
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/spf13/viper"
+)
+
+// runCoreTC returns a testConfiger with the bare minimum to walk through
+// run() far enough to exercise the next-stage seam. Every error-path test
+// starts from this and tweaks one field (or one seam) to break a specific
+// stage. Senders are disabled so the test doesn't open MQTT/HTTP cert
+// files unless the test explicitly opts in.
+func runCoreTC(t *testing.T) testConfiger {
+	t.Helper()
+	tc := defaultTC
+	tc.DataDir = t.TempDir()
+	tc.WellKnownDomainsFile = testDawgFile(t, "example.com.")
+	tc.InputUnix = filepath.Join(t.TempDir(), "dnstap.sock")
+	tc.MinimiserWorkers = 1
+	tc.QnameSeenEntries = 1
+	tc.CryptopanAddressEntries = 10
+	tc.NewQnameBuffer = 1
+	tc.DisableHistogramSender = true
+	tc.DisableMQTT = true
+	tc.DisableSessionFiles = true
+	return tc
+}
+
+// runCoreCleanup releases the global viper state and ephemeral HTTP-server
+// seam each error-path test installs, so subtests do not leak into one
+// another. callers register this via t.Cleanup before invoking run().
+func runCoreCleanup(t *testing.T) {
+	t.Helper()
+	t.Cleanup(viper.Reset)
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// pinHTTPServersToEphemeral overrides the pprof/metrics listen-addr seams
+// to ephemeral ports plus a listenAndServeHTTP that exits immediately, so
+// parallel tests do not collide on :6060/:2112 and the two server
+// goroutines never actually bind a port.
+func pinHTTPServersToEphemeral(t *testing.T) {
+	t.Helper()
+	swapSeam(t, &pprofListenAddr, "127.0.0.1:0")
+	swapSeam(t, &metricsListenAddr, "127.0.0.1:0")
+	swapSeam(t, &listenAndServeHTTP, func(*http.Server) error {
+		return http.ErrServerClosed
+	})
+}
+
+func TestRunCore_ErrorPaths(t *testing.T) {
+	t.Run("setIgnoredClientIPs error", func(t *testing.T) {
+		runCoreCleanup(t)
+		tc := runCoreTC(t)
+		tc.IgnoredClientIPsFile = filepath.Join(t.TempDir(), "missing.txt")
+		edm := newTestDnstapMinimiser(t, tc)
+		err := run(edm, discardLogger(), new(slog.LevelVar))
+		if err == nil || !strings.Contains(err.Error(), "ignored client IPs") {
+			t.Fatalf("err = %v, want ignored-client-IPs failure", err)
+		}
+	})
+
+	t.Run("setIgnoredQuestionNames error", func(t *testing.T) {
+		runCoreCleanup(t)
+		tc := runCoreTC(t)
+		tc.IgnoredQuestionNamesFile = filepath.Join(t.TempDir(), "missing.dawg")
+		edm := newTestDnstapMinimiser(t, tc)
+		err := run(edm, discardLogger(), new(slog.LevelVar))
+		if err == nil || !strings.Contains(err.Error(), "ignored question names") {
+			t.Fatalf("err = %v, want ignored-question-names failure", err)
+		}
+	})
+
+	t.Run("openPebble error", func(t *testing.T) {
+		runCoreCleanup(t)
+		swapSeam(t, &openPebble, func(string, *pebble.Options) (*pebble.DB, error) {
+			return nil, errInjected
+		})
+		tc := runCoreTC(t)
+		edm := newTestDnstapMinimiser(t, tc)
+		err := run(edm, discardLogger(), new(slog.LevelVar))
+		if !errors.Is(err, errInjected) {
+			t.Fatalf("err = %v, want errInjected", err)
+		}
+	})
+
+	t.Run("setupHistogramSender error", func(t *testing.T) {
+		runCoreCleanup(t)
+		tc := runCoreTC(t)
+		tc.DisableHistogramSender = false
+		// Missing cert/key files trip loadHTTPClientCert before
+		// setupHistogramSender; either way the error chain wraps "HTTP
+		// client cert" or "histogram sender".
+		tc.HTTPClientCertFile = filepath.Join(t.TempDir(), "missing.crt")
+		tc.HTTPClientKeyFile = filepath.Join(t.TempDir(), "missing.key")
+		edm := newTestDnstapMinimiser(t, tc)
+		err := run(edm, discardLogger(), new(slog.LevelVar))
+		if err == nil || !strings.Contains(err.Error(), "HTTP client cert") {
+			t.Fatalf("err = %v, want HTTP-client-cert failure", err)
+		}
+	})
+
+	t.Run("setupMQTT error", func(t *testing.T) {
+		runCoreCleanup(t)
+		tc := runCoreTC(t)
+		tc.DisableMQTT = false
+		// Real matching cert+key so loadMQTTClientCert succeeds and the
+		// failure surfaces from setupMQTT's missing-signing-key branch.
+		certPath, keyPath, _ := testCertFiles(t)
+		tc.MQTTClientCertFile = certPath
+		tc.MQTTClientKeyFile = keyPath
+		tc.MQTTSigningKeyFile = filepath.Join(t.TempDir(), "missing.jwk")
+		edm := newTestDnstapMinimiser(t, tc)
+		err := run(edm, discardLogger(), new(slog.LevelVar))
+		if err == nil || !strings.Contains(err.Error(), "setup mqtt") {
+			t.Fatalf("err = %v, want setup mqtt failure", err)
+		}
+	})
+
+	t.Run("setupDnstapInput no input", func(t *testing.T) {
+		runCoreCleanup(t)
+		tc := runCoreTC(t)
+		tc.InputUnix = ""
+		edm := newTestDnstapMinimiser(t, tc)
+		err := run(edm, discardLogger(), new(slog.LevelVar))
+		if !errors.Is(err, errNoInputConfigured) {
+			t.Fatalf("err = %v, want errNoInputConfigured", err)
+		}
+	})
+
+	t.Run("seen-qname LRU error", func(t *testing.T) {
+		runCoreCleanup(t)
+		tc := runCoreTC(t)
+		tc.QnameSeenEntries = 0
+		edm := newTestDnstapMinimiser(t, tc)
+		err := run(edm, discardLogger(), new(slog.LevelVar))
+		if err == nil || !strings.Contains(err.Error(), "seen-qname LRU") {
+			t.Fatalf("err = %v, want seen-qname LRU failure", err)
+		}
+	})
+
+	t.Run("loadDawgFile error", func(t *testing.T) {
+		runCoreCleanup(t)
+		pinHTTPServersToEphemeral(t)
+		tc := runCoreTC(t)
+		tc.WellKnownDomainsFile = filepath.Join(t.TempDir(), "missing.dawg")
+		edm := newTestDnstapMinimiser(t, tc)
+		err := run(edm, discardLogger(), new(slog.LevelVar))
+		if err == nil || !strings.Contains(err.Error(), "loadDawgFile") {
+			t.Fatalf("err = %v, want loadDawgFile failure", err)
+		}
+	})
+
+	t.Run("debug dnstap file open error", func(t *testing.T) {
+		runCoreCleanup(t)
+		pinHTTPServersToEphemeral(t)
+		tc := runCoreTC(t)
+		// A path under a regular file (not a directory) makes OpenFile
+		// fail with ENOTDIR regardless of the test user's uid.
+		blocker := writeTempFile(t, "blocker", []byte("x"))
+		tc.DebugDnstapFilename = filepath.Join(blocker, "debug.dnstap")
+		edm := newTestDnstapMinimiser(t, tc)
+		err := run(edm, discardLogger(), new(slog.LevelVar))
+		if err == nil || !strings.Contains(err.Error(), "debug dnstap file") {
+			t.Fatalf("err = %v, want debug dnstap file failure", err)
+		}
+	})
+}


### PR DESCRIPTION
## What

Stage 8b — test PR for the new \`run()\` core extracted in #217. Drives \`run()\` directly with a
\`testConfiger\` built from \`defaultTC\` + per-case field overrides, asserting each
return-error site fires its expected wrap.

## Cases

- **\`setIgnoredClientIPs error\`** — \`IgnoredClientIPsFile\` set to a missing path
- **\`setIgnoredQuestionNames error\`** — \`IgnoredQuestionNamesFile\` set to a missing dawg
- **\`openPebble error\`** — \`openPebble\` seam returns \`errInjected\`
- **\`setupHistogramSender error\`** — \`DisableHistogramSender=false\` + missing
  \`HTTPClientCertFile\`/\`HTTPClientKeyFile\` so \`loadHTTPClientCert\` trips before
  \`setupHistogramSender\` is reached
- **\`setupMQTT error\`** — \`DisableMQTT=false\` with a real matching cert+key (from
  \`testCertFiles\`) so the failure surfaces from \`setupMQTT\`'s missing-signing-key
  branch rather than from cert loading
- **\`setupDnstapInput no input\`** — all of \`InputUnix\`/\`InputTCP\`/\`InputTLS\` empty,
  yielding \`errNoInputConfigured\` (the sentinel added in #213)
- **\`seen-qname LRU error\`** — \`QnameSeenEntries=0\` rejected by \`lru.New\`
- **\`loadDawgFile error\`** — \`WellKnownDomainsFile\` set to a missing path; pprof/metrics
  listen-addr seams pinned to \`127.0.0.1:0\` and \`listenAndServeHTTP\` stubbed to
  \`http.ErrServerClosed\` so the started goroutines don't try to bind \`:6060\`/\`:2112\`
- **\`debug dnstap file open error\`** — \`DebugDnstapFilename\` placed below a regular
  file → \`ENOTDIR\` (root-safe; same trick \`TestSetupMQTT/queue dir creation failure\`
  used)

Shared helpers (\`runCoreTC\`, \`runCoreCleanup\`, \`discardLogger\`,
\`pinHTTPServersToEphemeral\`) keep each subtest focused on the single knob it tests.

## Coverage

- \`run\`: 66.7% → **80.2%**
- \`pkg/runner\`: 82.9% → **83.9%**

## Residual

The post-error-path tail of \`run()\` — workers start through orderly shutdown — is
already covered by \`TestRunWithDisabledSenders\` (the canary). The
manual-rotation-enabled, MQTT-enabled, and debug-profiling-flags happy-paths called out
in the stage-8 plan are deferred to **stage 9** backfill (which also picks up
\`configUpdater\`, \`fsEventWatcher\`, \`diskCleaner\`/\`histogramSender\` ticker branches,
and the remaining worker-loop gaps).

## Verification

\`go test -race ./pkg/runner/\` green; \`golangci-lint run ./...\` reports 0 issues;
\`gofumpt\` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive error-path tests for core runner behavior, covering configuration validation failures, certificate and HTTP client errors, message broker setup issues, missing inputs/resources, and file-system edge cases to improve reliability and detect regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->