### PR TITLE
test(runner): cover mqttPublishWorker error/reason-code branches (coverage stage 9)

### DIFF
--- a/pkg/runner/mqtt_test.go
+++ b/pkg/runner/mqtt_test.go
@@ -1,11 +1,13 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"io"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -343,6 +345,86 @@ func TestMqttPublishWorkerExitsOnContextCancel(t *testing.T) {
 
 	cancel()
 	waitOrFail(t, &edm.autopahoWg, 2*time.Second, "mqttPublishWorker did not exit after context cancel")
+}
+
+// TestMqttPublishWorkerLogsPublishError feeds a signed message at a fake
+// connection manager whose Publish returns errInjected; the worker logs
+// "error publishing" and continues to the next iteration rather than
+// exiting. Closing mqttSignedCh ends the loop.
+func TestMqttPublishWorkerLogsPublishError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	edm, err := newDnstapMinimiser(logger, defaultTC)
+	if err != nil {
+		t.Fatalf("newDnstapMinimiser: %s", err)
+	}
+	t.Cleanup(func() { cleanupMQTTTestMinimiser(edm) })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	edm.autopahoCtx = ctx
+	t.Cleanup(cancel)
+
+	edm.mqttSignedCh = make(chan []byte, 1)
+	conn := &fakeAutoPahoConnection{
+		publishedCh: make(chan struct{}, 1),
+		publishErr:  errInjected,
+	}
+
+	edm.autopahoWg.Add(1)
+	go edm.mqttPublishWorker(conn, "events/up/test/new_qname", false)
+
+	edm.mqttSignedCh <- []byte(`{"hi":"there"}`)
+	select {
+	case <-conn.publishedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Publish was never called")
+	}
+	close(edm.mqttSignedCh)
+	waitOrFail(t, &edm.autopahoWg, 2*time.Second, "mqttPublishWorker did not exit")
+
+	if !strings.Contains(buf.String(), "error publishing") {
+		t.Fatalf("expected error log, got: %q", buf.String())
+	}
+}
+
+// TestMqttPublishWorkerLogsNonZeroReasonCode covers the QoS-1+ "reason
+// code received" log: a non-nil PublishResponse with a ReasonCode that
+// is neither 0 (success) nor 16 (no-subscribers, which is silenced) is
+// logged at info.
+func TestMqttPublishWorkerLogsNonZeroReasonCode(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	edm, err := newDnstapMinimiser(logger, defaultTC)
+	if err != nil {
+		t.Fatalf("newDnstapMinimiser: %s", err)
+	}
+	t.Cleanup(func() { cleanupMQTTTestMinimiser(edm) })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	edm.autopahoCtx = ctx
+	t.Cleanup(cancel)
+
+	edm.mqttSignedCh = make(chan []byte, 1)
+	conn := &fakeAutoPahoConnection{
+		publishedCh: make(chan struct{}, 1),
+		publishResp: &paho.PublishResponse{ReasonCode: 0x80},
+	}
+
+	edm.autopahoWg.Add(1)
+	go edm.mqttPublishWorker(conn, "events/up/test/new_qname", false)
+
+	edm.mqttSignedCh <- []byte(`{"hi":"there"}`)
+	select {
+	case <-conn.publishedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Publish was never called")
+	}
+	close(edm.mqttSignedCh)
+	waitOrFail(t, &edm.autopahoWg, 2*time.Second, "mqttPublishWorker did not exit")
+
+	if !strings.Contains(buf.String(), "reason code received") {
+		t.Fatalf("expected reason code log, got: %q", buf.String())
+	}
 }
 
 // waitOrFail waits for wg with a deadline, calling t.Fatalf with the

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -1346,6 +1346,12 @@ type fakeAutoPahoConnection struct {
 	published   []*paho.Publish
 	awaitErr    error
 	publishedCh chan struct{}
+	// publishErr, if non-nil, is returned from Publish so the
+	// mqttPublishWorker's error log branch can be exercised.
+	publishErr error
+	// publishResp, if non-nil, is returned from Publish; otherwise
+	// Publish returns &paho.PublishResponse{} (ReasonCode 0).
+	publishResp *paho.PublishResponse
 }
 
 func (f *fakeAutoPahoConnection) AwaitConnection(context.Context) error {
@@ -1361,6 +1367,12 @@ func (f *fakeAutoPahoConnection) Publish(_ context.Context, p *paho.Publish) (*p
 		case f.publishedCh <- struct{}{}:
 		default:
 		}
+	}
+	if f.publishErr != nil {
+		return nil, f.publishErr
+	}
+	if f.publishResp != nil {
+		return f.publishResp, nil
 	}
 	return &paho.PublishResponse{}, nil
 }


### PR DESCRIPTION
## What

Fifth slice of stage 9 — covers the two log-only arms of \`mqttPublishWorker\` that the
existing serial/cancel tests leave at 78.6%:

- **\`TestMqttPublishWorkerLogsPublishError\`** — \`fakeAutoPahoConnection\` now exposes a
  \`publishErr\` field; the worker's "error publishing" log fires when \`cm.Publish\`
  returns it. The worker keeps looping (does not exit on a publish error) and shuts
  down when \`mqttSignedCh\` is closed.
- **\`TestMqttPublishWorkerLogsNonZeroReasonCode\`** — \`fakeAutoPahoConnection\` also
  exposes \`publishResp\`; setting \`ReasonCode=0x80\` (non-zero, non-16) exercises the
  QoS-1+ "reason code received" info log. (0 is success, 16 = "no subscribers" and is
  silenced.)

\`fakeAutoPahoConnection.Publish\` keeps its default behaviour (\`PublishResponse{}\` +
nil error) when neither \`publishErr\` nor \`publishResp\` is set, so existing tests are
unchanged.

## Coverage

- \`mqttPublishWorker\`: 78.6% → **85.7%**
- \`pkg/runner\`: 85.7% → **85.8%**

## Verification

\`go test -race -count=2 ./pkg/runner/\` green; \`golangci-lint run ./...\` reports 0 issues.