### PR TITLE
ci(build): only publish coverage badge on push to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,10 @@ jobs:
 
   coverage:
     needs: build
+    # Publishing the coverage badge pushes to the repository, so only run this
+    # after a merge to main. On pull requests (which may originate from forks)
+    # the job has no business rewriting the badge and lacks the write access.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

The `coverage` job in `build.yml` publishes the coverage badge via `linkdata/gitcoverage`, which pushes to the repository and therefore declares `permissions: contents: write`. It runs on **every** `pull_request` event, where it fails fast — a pull request (especially one from a fork) must not rewrite the badge and doesn't have the write access. This turns the checks red on PRs even when `build` itself is green.

See e.g. #197, where `build` passes but `coverage` fails in ~7s.

## Fix

Gate the `coverage` job so it only runs after a merge to `main`:

```yaml
if: github.event_name == 'push' && github.ref == 'refs/heads/main'
```

The `build` job (generate, vet, gofmt, staticcheck, golangci-lint, gosec, `go test -race`, coverage artifact upload, build) still runs on every pull request, so PRs keep full CI coverage — only the badge **publish** step is deferred to post-merge.

## Note

If `coverage` is currently listed as a *required* status check in branch protection, it should be removed (an `if`-skipped job never reports a status). The meaningful PR gate is the `build` job.