### PR TITLE
fix(runner): disk-cleaner retention + fs-watcher lock + config-updater shutdown

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -619,13 +619,26 @@ func configUpdater(viperNotifyCh chan fsnotify.Event, edm *dnstapMinimiser) {
 	})
 	t.Stop()
 
-	for e = range viperNotifyCh {
-		// If an event has been recevied this means we now want to
-		// enable the timer so the function will be called "soon", but
-		// if more events occur we will reset it again. This allows us
-		// to wait until events on the file settles down before
-		// actually calling the update function.
-		t.Reset(configUpdateDebounce)
+	for {
+		select {
+		case event, ok := <-viperNotifyCh:
+			if !ok {
+				// Mirror the ctx.Done() branch: stop the debounce timer so a
+				// pending callback cannot fire after configUpdater returns.
+				t.Stop()
+				return
+			}
+			e = event
+			// If an event has been received this means we now want to
+			// enable the timer so the function will be called "soon", but
+			// if more events occur we will reset it again. This allows us
+			// to wait until events on the file settles down before
+			// actually calling the update function.
+			t.Reset(configUpdateDebounce)
+		case <-edm.ctx.Done():
+			t.Stop()
+			return
+		}
 	}
 }
 
@@ -1276,12 +1289,15 @@ func run(edm *dnstapMinimiser, logger *slog.Logger, loggerLevel *slog.LevelVar) 
 		return fmt.Errorf("unable to configure ignored question names: %w", err)
 	}
 
-	viperNotifyCh := make(chan fsnotify.Event)
+	viperNotifyCh := make(chan fsnotify.Event, 1)
 
 	go configUpdater(viperNotifyCh, edm)
 
 	viper.OnConfigChange(func(e fsnotify.Event) {
-		viperNotifyCh <- e
+		select {
+		case viperNotifyCh <- e:
+		default:
+		}
 	})
 
 	pdbDir := filepath.Join(startConf.DataDir, "pebble")
@@ -1494,6 +1510,14 @@ func run(edm *dnstapMinimiser, logger *slog.Logger, loggerLevel *slog.LevelVar) 
 	// deferred cleanup registered when they were started.
 	edm.log.Info("Run: waiting for other workers to exit")
 	wg.Wait()
+
+	// configUpdater is not tracked by wg; it observes the same edm.ctx
+	// cancellation as the wg workers and returns on its own. viperNotifyCh is
+	// deliberately left open: viper's config watcher started by WatchConfig
+	// outlives run and keeps invoking the OnConfigChange callback, so closing
+	// the channel here would let a later config change panic on a send to a
+	// closed channel. The buffered channel plus the callback's non-blocking
+	// send keep that callback from blocking once configUpdater has stopped.
 
 	// Wait for graceful disconnection from MQTT bus
 	if !startConf.DisableMQTT {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1107,6 +1107,7 @@ func (edm *dnstapMinimiser) addFSWatchers(fileToFuncs map[string][]func() error)
 
 func (edm *dnstapMinimiser) cleanupFSWatchers() error {
 	edm.fsWatcherMutex.RLock()
+	defer edm.fsWatcherMutex.RUnlock()
 	for _, watchPath := range edm.fsWatcher.WatchList() {
 		watchPathInUse := false
 		for fsWatcherFuncFilename := range edm.fsWatcherFuncs {
@@ -1117,13 +1118,12 @@ func (edm *dnstapMinimiser) cleanupFSWatchers() error {
 
 		if !watchPathInUse {
 			edm.log.Info("cleanupFSWatchers: cleaning up path watcher", "watch_path", watchPath)
-			err := edm.fsWatcher.Remove(watchPath)
+			err := removeFSWatcherPath(edm.fsWatcher, watchPath)
 			if err != nil {
 				return fmt.Errorf("cleanupFSWatchers: unable to remove path watcher '%s': %w", watchPath, err)
 			}
 		}
 	}
-	edm.fsWatcherMutex.RUnlock()
 
 	return nil
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -378,14 +378,18 @@ func (edm *dnstapMinimiser) reverseLabelsBounded(labels []string, maxLen int) []
 	return boundedReverseLabels
 }
 
+const sentHistogramRetention = 24 * time.Hour
+
+func sentHistogramExpired(modTime, now time.Time) bool {
+	return now.Sub(modTime) > sentHistogramRetention
+}
+
 func (edm *dnstapMinimiser) diskCleaner(wg *sync.WaitGroup, sentDir string) {
 	// We will scan the directory each tick for sent files to remove.
 	defer wg.Done()
 
 	ticker := time.NewTicker(diskCleanerInterval)
 	defer ticker.Stop()
-
-	oneDay := time.Hour * 12
 
 timerLoop:
 	for {
@@ -411,7 +415,7 @@ timerLoop:
 						continue
 					}
 
-					if time.Since(fileInfo.ModTime()) > oneDay {
+					if sentHistogramExpired(fileInfo.ModTime(), time.Now()) {
 						absPath := filepath.Join(sentDir, dirEntry.Name())
 						edm.log.Info("diskCleaner: removing file", "filename", absPath)
 						err = osRemove(absPath)

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -2359,7 +2359,7 @@ func TestMonitorAndDiskCleaner(t *testing.T) {
 		if err := os.WriteFile(oldFile, []byte("x"), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		oldTime := time.Now().Add(-13 * time.Hour)
+		oldTime := time.Now().Add(-25 * time.Hour)
 		if err := os.Chtimes(oldFile, oldTime, oldTime); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -2359,7 +2359,8 @@ func TestMonitorAndDiskCleaner(t *testing.T) {
 		if err := os.WriteFile(oldFile, []byte("x"), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		oldTime := time.Now().Add(-25 * time.Hour)
+		// One hour past the retention window, so diskCleaner must remove it.
+		oldTime := time.Now().Add(-sentHistogramRetention - time.Hour)
 		if err := os.Chtimes(oldFile, oldTime, oldTime); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -2144,3 +2144,34 @@ func TestDiskCleanerRetentionThreshold(t *testing.T) {
 		t.Fatal("histogram newer than 24 hours should not expire")
 	}
 }
+
+func TestCleanupFSWatchersReleasesLockOnError(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+
+	// Watch a directory that is not referenced by any callback so
+	// cleanupFSWatchers tries to remove it.
+	if err := edm.fsWatcher.Add(t.TempDir()); err != nil {
+		t.Fatalf("Add watch path: %s", err)
+	}
+	edm.fsWatcherFuncs = make(map[string][]func() error)
+
+	removeErr := errors.New("remove failed")
+	oldRemoveFSWatcherPath := removeFSWatcherPath
+	removeFSWatcherPath = func(_ *fsnotify.Watcher, _ string) error {
+		return removeErr
+	}
+	t.Cleanup(func() {
+		removeFSWatcherPath = oldRemoveFSWatcherPath
+	})
+
+	err := edm.cleanupFSWatchers()
+	if !errors.Is(err, removeErr) {
+		t.Fatalf("cleanupFSWatchers error have: %v, want: %v", err, removeErr)
+	}
+
+	// The RLock must have been released even though removal failed.
+	if !edm.fsWatcherMutex.TryLock() {
+		t.Fatal("fsWatcherMutex.TryLock() failed - mutex is still locked after cleanupFSWatchers")
+	}
+	edm.fsWatcherMutex.Unlock()
+}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -2132,3 +2132,15 @@ func TestWriteHistogramParquetExplicitThreshold(t *testing.T) {
 		}
 	}
 }
+
+func TestDiskCleanerRetentionThreshold(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+
+	if !sentHistogramExpired(now.Add(-25*time.Hour), now) {
+		t.Fatal("histogram older than 24 hours should expire")
+	}
+
+	if sentHistogramExpired(now.Add(-23*time.Hour), now) {
+		t.Fatal("histogram newer than 24 hours should not expire")
+	}
+}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -2136,12 +2137,18 @@ func TestWriteHistogramParquetExplicitThreshold(t *testing.T) {
 func TestDiskCleanerRetentionThreshold(t *testing.T) {
 	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
 
-	if !sentHistogramExpired(now.Add(-25*time.Hour), now) {
-		t.Fatal("histogram older than 24 hours should expire")
+	if !sentHistogramExpired(now.Add(-sentHistogramRetention-time.Hour), now) {
+		t.Fatal("histogram older than the retention window should expire")
 	}
 
-	if sentHistogramExpired(now.Add(-23*time.Hour), now) {
-		t.Fatal("histogram newer than 24 hours should not expire")
+	if sentHistogramExpired(now.Add(-sentHistogramRetention+time.Hour), now) {
+		t.Fatal("histogram within the retention window should not expire")
+	}
+
+	// Exactly at the retention boundary: sentHistogramExpired uses a strict
+	// greater-than, so a histogram aged exactly 24 hours is not yet expired.
+	if sentHistogramExpired(now.Add(-sentHistogramRetention), now) {
+		t.Fatal("histogram exactly at the 24 hour retention boundary should not expire")
 	}
 }
 
@@ -2174,4 +2181,60 @@ func TestCleanupFSWatchersReleasesLockOnError(t *testing.T) {
 		t.Fatal("fsWatcherMutex.TryLock() failed - mutex is still locked after cleanupFSWatchers")
 	}
 	edm.fsWatcherMutex.Unlock()
+}
+
+func TestConfigUpdaterExitsOnContextCancel(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+
+	viperNotifyCh := make(chan fsnotify.Event, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		configUpdater(viperNotifyCh, edm)
+	}()
+
+	// Cancelling the context is sticky, so configUpdater observes it via its
+	// select regardless of whether the goroutine has reached the select yet.
+	edm.stop()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("configUpdater did not exit after context cancel")
+	}
+}
+
+func TestConfigUpdaterExitsOnChannelClose(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+
+	viperNotifyCh := make(chan fsnotify.Event, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		configUpdater(viperNotifyCh, edm)
+	}()
+
+	// Closing viperNotifyCh makes the receive return ok=false, which
+	// configUpdater treats as a shutdown signal and returns.
+	close(viperNotifyCh)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("configUpdater did not exit after viperNotifyCh close")
+	}
 }

--- a/pkg/runner/seams.go
+++ b/pkg/runner/seams.go
@@ -42,6 +42,12 @@ var (
 	osReadDir  = os.ReadDir
 	osStat     = os.Stat
 
+	// removeFSWatcherPath wraps (*fsnotify.Watcher).Remove so tests can
+	// inject removal failures into cleanupFSWatchers.
+	removeFSWatcherPath = func(w *fsnotify.Watcher, path string) error {
+		return w.Remove(path)
+	}
+
 	now                     = time.Now
 	configUpdateDebounce    = 100 * time.Millisecond
 	fsEventDebounce         = 100 * time.Millisecond


### PR DESCRIPTION
Combines three coupled `runner` fixes that touch overlapping code (so they must merge together) into one PR — supersedes #173, #177, #186.

- **#173** — retain sent histograms for a true 24h (`sentHistogramRetention` const + `sentHistogramExpired` helper in `diskCleaner`).
- **#177** — `cleanupFSWatchers` releases the `fsWatcherMutex` RLock via `defer` on the removal-error path (was leaked).
- **#186** — config updater stops on shutdown: `select` on `ctx.Done()`, buffered `viperNotifyCh` + non-blocking `OnConfigChange` send.

Each fix is a separate commit. Verified: `go build`, `go vet`, `staticcheck`, `golangci-lint`, `go test -race ./...` all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Sent-histogram disk retention extended to 24 hours to reduce premature cleanup.
  * Configuration reloads hardened to avoid shutdown races and event-burst hazards.
  * Filesystem watcher cleanup made more reliable, with improved error handling and lock-release behavior.

* **Tests**
  * Added and updated tests covering retention thresholds, watcher cleanup error handling, and configuration-updater termination scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->