### PR TITLE
feat(runner): minimiser hardening — pebble-sync, qname dedupe, cancellable session send, malformed-frame skip

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/miekg/dns v1.1.72
 	github.com/parquet-go/parquet-go v0.27.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/segmentio/go-hll v1.0.1
 	github.com/smhanov/dawg v0.0.0-20220118194912-66057bdbf2e3
 	github.com/spaolacci/murmur3 v1.1.0
@@ -70,7 +71,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pierrec/lz4/v4 v4.1.25 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -35,6 +35,7 @@ func init() {
 	runCmd.Flags().Bool("disable-mqtt", false, "disable MQTT message sending")
 	runCmd.Flags().Bool("disable-mqtt-filequeue", false, "disable MQTT file based queue")
 	runCmd.Flags().Bool("enable-manual-parquet-rotation", false, "enable localhost HTTP endpoint for manually rotating session and histogram parquet files")
+	runCmd.Flags().Bool("pebble-sync", false, "fsync seen-qname pebble writes")
 
 	runCmd.Flags().String("input-unix", "", "create unix socket for reading dnstap (e.g. /var/lib/unbound/dnstap.sock)")
 	runCmd.Flags().String("input-tcp", "", "create TCP socket for reading dnstap (e.g. '127.0.0.1:53535')")

--- a/pkg/runner/qnameseen_bench_test.go
+++ b/pkg/runner/qnameseen_bench_test.go
@@ -1,0 +1,52 @@
+package runner
+
+import (
+	"strconv"
+	"testing"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/miekg/dns"
+)
+
+// BenchmarkQnameSeen measures the qnameSeen hot path: a qname that has already
+// been seen, which is the common per-packet case in runMinimiser (the first
+// sighting of any qname happens once; every later packet for it takes this
+// LRU-hit path). It runs in parallel because runMinimiser fans out across
+// workers that all share one seenQnameLRU, one pebble DB, and seenQnameMutex, so
+// the benchmark reflects the real contention on those shared structures.
+func BenchmarkQnameSeen(b *testing.B) {
+	edm := newTestDnstapMinimiser(b, defaultTC)
+
+	const nQnames = 10_000
+	cache, err := lru.New[string, struct{}](nQnames * 2) // oversized so nothing is evicted
+	if err != nil {
+		b.Fatalf("lru.New: %s", err)
+	}
+	pdb := newTestPebble(b)
+	writeOpts := seenQnameWriteOptions(defaultTC.config)
+
+	msgs := make([]*dns.Msg, nQnames)
+	for i := range msgs {
+		m := new(dns.Msg)
+		m.SetQuestion("host"+strconv.Itoa(i)+".example.com.", dns.TypeA)
+		msgs[i] = m
+		// Record it so the benchmarked calls below all take the seen path.
+		edm.qnameSeen(m, cache, pdb, writeOpts)
+	}
+
+	// Sanity check (in the benchmark goroutine, not the parallel workers): a
+	// seeded qname must report as already seen.
+	if !edm.qnameSeen(msgs[0], cache, pdb, writeOpts) {
+		b.Fatal("seeded qname should report as already seen")
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			edm.qnameSeen(msgs[i%nQnames], cache, pdb, writeOpts)
+			i++
+		}
+	})
+}

--- a/pkg/runner/run_minimiser_test.go
+++ b/pkg/runner/run_minimiser_test.go
@@ -1,0 +1,17 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+)
+
+func TestSeenQnameWriteOptions(t *testing.T) {
+	if got := seenQnameWriteOptions(config{}); got != pebble.NoSync {
+		t.Fatalf("default seen-qname write option = %p, want %p", got, pebble.NoSync)
+	}
+
+	if got := seenQnameWriteOptions(config{PebbleSync: true}); got != pebble.Sync {
+		t.Fatalf("pebble-sync seen-qname write option = %p, want %p", got, pebble.Sync)
+	}
+}

--- a/pkg/runner/run_minimiser_test.go
+++ b/pkg/runner/run_minimiser_test.go
@@ -1,9 +1,18 @@
 package runner
 
 import (
+	"io"
+	"log/slog"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/pebble"
+	dnstap "github.com/dnstap/golang-dnstap"
+	"github.com/dnstapir/edm/pkg/protocols"
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/miekg/dns"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestSeenQnameWriteOptions(t *testing.T) {
@@ -14,4 +23,162 @@ func TestSeenQnameWriteOptions(t *testing.T) {
 	if got := seenQnameWriteOptions(config{PebbleSync: true}); got != pebble.Sync {
 		t.Fatalf("pebble-sync seen-qname write option = %p, want %p", got, pebble.Sync)
 	}
+}
+
+func TestQnameSeenConcurrentFirstSeenOnce(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+
+	seenQnameLRU, err := lru.New[string, struct{}](10)
+	if err != nil {
+		t.Fatalf("lru.New: %s", err)
+	}
+
+	pdb := newTestPebble(t)
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("race.example.", dns.TypeA)
+
+	const goroutines = 64
+	start := make(chan struct{})
+	results := make(chan bool, goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			results <- edm.qnameSeen(msg, seenQnameLRU, pdb, defaultTC.config)
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+
+	var firstSeen int
+	for seen := range results {
+		if !seen {
+			firstSeen++
+		}
+	}
+	if firstSeen != 1 {
+		t.Fatalf("first-seen results have: %d, want: 1", firstSeen)
+	}
+}
+
+// TestRunMinimiserSessionSendUnblocksOnContextCancel verifies that
+// runMinimiser stops blocking on a full sessionCollectorCh once the context
+// is cancelled.
+//
+// sessionCollectorCh is pre-filled to capacity so the session send blocks, and
+// newQnamePublisherCh is left unbuffered so receiving the new_qname event
+// proves runMinimiser has reached the session send. With the send guarded by a
+// select on edm.ctx.Done, cancelling the context lets runMinimiser exit; an
+// unconditional send would deadlock and waitOrFail would time out.
+func TestRunMinimiserSessionSendUnblocksOnContextCancel(t *testing.T) {
+	edm := newTestDnstapMinimiser(t, defaultTC)
+	edm.reloadMinimiserConfigCh = []chan struct{}{make(chan struct{}, 1)}
+	edm.newQnamePublisherCh = make(chan *protocols.NewQnameJSON)
+	edm.sessionCollectorCh = make(chan *sessionData, 1)
+	edm.sessionCollectorCh <- &sessionData{}
+
+	seenQnameLRU, err := lru.New[string, struct{}](10)
+	if err != nil {
+		t.Fatalf("lru.New: %s", err)
+	}
+	pdb := newTestPebble(t)
+	wkdTracker, err := newWellKnownDomainsTracker(testDawgFinder(t, "known.example."), time.Unix(0, 0))
+	if err != nil {
+		t.Fatalf("newWellKnownDomainsTracker: %s", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go edm.runMinimiser(0, &wg, seenQnameLRU, pdb, nil, defaultLabelLimit, wkdTracker)
+
+	frame := marshaledDnstap(t, testDnstapMessage(t, dnstap.Message_CLIENT_RESPONSE, dnstap.SocketFamily_INET, packedDNSMsg(t, "new.example.", dns.TypeA, dns.RcodeSuccess)))
+	edm.inputChannel <- frame
+
+	// Receiving the new_qname event proves runMinimiser is past the
+	// publisher send and about to perform the (blocked) session send.
+	select {
+	case <-edm.newQnamePublisherCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for new_qname event")
+	}
+
+	edm.stop()
+	waitOrFail(t, &wg, 2*time.Second, "runMinimiser did not exit while blocked on a full sessionCollectorCh after context cancellation")
+}
+
+func TestRunMinimiserSkipsMalformedFrames(t *testing.T) {
+	edm, seenQnameLRU, pdb, wkdTracker := newRunMinimiserTestFixture(t, "example.com.")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go edm.runMinimiser(0, &wg, seenQnameLRU, pdb, nil, defaultLabelLimit, wkdTracker)
+	t.Cleanup(func() {
+		edm.stop()
+		waitOrFail(t, &wg, 2*time.Second, "runMinimiser did not exit after stop")
+	})
+
+	// Not protobuf at all.
+	edm.inputChannel <- []byte{0xff, 0x01, 0x02}
+	// Valid envelope but no Message.
+	edm.inputChannel <- marshaledDnstap(t, &dnstap.Dnstap{Type: dnstap.Dnstap_MESSAGE.Enum()})
+	// Message present but its required Type is missing.
+	edm.inputChannel <- marshalPartialDnstap(t, &dnstap.Dnstap{
+		Type:    dnstap.Dnstap_MESSAGE.Enum(),
+		Message: &dnstap.Message{},
+	})
+	// A well-formed response for a well-known domain must still be processed.
+	edm.inputChannel <- marshaledDnstap(t, testDnstapMessage(t, dnstap.Message_CLIENT_RESPONSE, dnstap.SocketFamily_INET, packedDNSMsg(t, "example.com.", dns.TypeA, dns.RcodeSuccess)))
+
+	select {
+	case wu := <-wkdTracker.updateCh:
+		if wu.dawgIndex == dawgNotFound {
+			t.Fatal("valid frame after malformed input was not treated as well-known")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("valid frame after malformed input was not processed")
+	}
+}
+
+func newRunMinimiserTestFixture(t *testing.T, knownDomains ...string) (*dnstapMinimiser, *lru.Cache[string, struct{}], *pebble.DB, *wellKnownDomainsTracker) {
+	t.Helper()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	edm, err := newDnstapMinimiser(logger, defaultTC)
+	if err != nil {
+		t.Fatalf("newDnstapMinimiser: %s", err)
+	}
+	t.Cleanup(edm.stop)
+	edm.reloadMinimiserConfigCh = []chan struct{}{make(chan struct{}, 1)}
+
+	seenQnameLRU, err := lru.New[string, struct{}](10)
+	if err != nil {
+		t.Fatalf("lru.New: %s", err)
+	}
+
+	pdb := newTestPebble(t)
+
+	wkdTracker, err := newWellKnownDomainsTracker(testDawgFinder(t, knownDomains...), time.Time{})
+	if err != nil {
+		t.Fatalf("newWellKnownDomainsTracker: %s", err)
+	}
+
+	return edm, seenQnameLRU, pdb, wkdTracker
+}
+
+// marshalPartialDnstap marshals dt without enforcing required fields, allowing
+// frames that exercise the minimiser's nil/missing-field guards.
+func marshalPartialDnstap(t *testing.T, dt *dnstap.Dnstap) []byte {
+	t.Helper()
+
+	frame, err := proto.MarshalOptions{AllowPartial: true}.Marshal(dt)
+	if err != nil {
+		t.Fatalf("proto.Marshal: %s", err)
+	}
+	return frame
 }

--- a/pkg/runner/run_minimiser_test.go
+++ b/pkg/runner/run_minimiser_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dnstapir/edm/pkg/protocols"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/miekg/dns"
+	dto "github.com/prometheus/client_model/go"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -44,11 +45,11 @@ func TestQnameSeenConcurrentFirstSeenOnce(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		go func() {
 			defer wg.Done()
 			<-start
-			results <- edm.qnameSeen(msg, seenQnameLRU, pdb, defaultTC.config)
+			results <- edm.qnameSeen(msg, seenQnameLRU, pdb, seenQnameWriteOptions(defaultTC.config))
 		}()
 	}
 
@@ -72,14 +73,16 @@ func TestQnameSeenConcurrentFirstSeenOnce(t *testing.T) {
 // is cancelled.
 //
 // sessionCollectorCh is pre-filled to capacity so the session send blocks, and
-// newQnamePublisherCh is left unbuffered so receiving the new_qname event
-// proves runMinimiser has reached the session send. With the send guarded by a
-// select on edm.ctx.Done, cancelling the context lets runMinimiser exit; an
-// unconditional send would deadlock and waitOrFail would time out.
+// newQnamePublisherCh is buffered (cap 1) so runMinimiser's non-blocking
+// publisher send lands in the buffer instead of being dropped by its default
+// case; receiving that event proves runMinimiser is past the publisher send and
+// into the (blocked) session send. With the send guarded by a select on
+// edm.ctx.Done, cancelling the context lets runMinimiser exit; an unconditional
+// send would deadlock and waitOrFail would time out.
 func TestRunMinimiserSessionSendUnblocksOnContextCancel(t *testing.T) {
 	edm := newTestDnstapMinimiser(t, defaultTC)
 	edm.reloadMinimiserConfigCh = []chan struct{}{make(chan struct{}, 1)}
-	edm.newQnamePublisherCh = make(chan *protocols.NewQnameJSON)
+	edm.newQnamePublisherCh = make(chan *protocols.NewQnameJSON, 1)
 	edm.sessionCollectorCh = make(chan *sessionData, 1)
 	edm.sessionCollectorCh <- &sessionData{}
 
@@ -142,6 +145,20 @@ func TestRunMinimiserSkipsMalformedFrames(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("valid frame after malformed input was not processed")
+	}
+
+	// Exactly one parse error is counted: only the missing-Message frame both
+	// unmarshals and reaches a parse-error guard. The non-protobuf frame and
+	// the missing-Type frame fail proto.Unmarshal first (dnstap is proto2, so a
+	// Message without its required Type is rejected on unmarshal) and are
+	// skipped without counting. The valid frame is processed after all three,
+	// so by the time it reaches wkdTracker the counter has settled.
+	var m dto.Metric
+	if err := edm.promDNSParseError.Write(&m); err != nil {
+		t.Fatalf("write promDNSParseError: %s", err)
+	}
+	if got := m.GetCounter().GetValue(); got != 1 {
+		t.Fatalf("promDNSParseError = %v, want 1", got)
 	}
 }
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1552,6 +1552,7 @@ type dnstapMinimiser struct {
 	reloadMinimiserMutex          sync.RWMutex
 	reloadMinimiserConfigCh       []chan struct{}
 	reloadHistogramSenderConfigCh chan struct{}
+	seenQnameLocks                [seenQnameLockShards]sync.Mutex
 }
 
 func createCryptopan(key string, salt string) (*cryptopan.Cryptopan, error) {
@@ -1917,18 +1918,32 @@ func seenQnameWriteOptions(conf config) *pebble.WriteOptions {
 	return pebble.NoSync
 }
 
+// seenQnameLockShards is the number of mutexes sharding qnameSeen by qname.
+//
+// It bounds [dnstapMinimiser.seenQnameLocks] and the modulus in
+// [seenQnameLockIndex], so both stay in sync.
+const seenQnameLockShards = 256
+
+// seenQnameLockIndex maps qname to a shard in [dnstapMinimiser.seenQnameLocks].
+//
+// It hashes qname with FNV-1a and reduces the result modulo
+// [seenQnameLockShards], so the returned index is always a valid offset into
+// the lock array.
+func seenQnameLockIndex(qname string) int {
+	var h uint32 = 2166136261
+	for i := 0; i < len(qname); i++ {
+		h ^= uint32(qname[i])
+		h *= 16777619
+	}
+	return int(h % seenQnameLockShards)
+}
+
 // Check if we have already seen this qname since we started.
 func (edm *dnstapMinimiser) qnameSeen(msg *dns.Msg, seenQnameLRU *lru.Cache[string, struct{}], pdb *pebble.DB, conf config) bool {
-	// NOTE: This looks like it might be a race (calling
-	// Get() followed by separate Add()) but since we want
-	// to keep often looked-up names in the cache we need to
-	// use Get() for updating recent-ness, and there is no
-	// GetOrAdd() method available. However, it should be
-	// safe for multiple threads to call Add() as this will
-	// only move an already added entry to the front of the
-	// eviction list which should be OK.
-
 	qname := strings.ToLower(msg.Question[0].Name)
+	seenLock := &edm.seenQnameLocks[seenQnameLockIndex(qname)]
+	seenLock.Lock()
+	defer seenLock.Unlock()
 
 	_, ok := seenQnameLRU.Get(qname)
 	if ok {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -2161,7 +2161,10 @@ minimiserLoop:
 
 			if !conf.DisableSessionFiles {
 				session := edm.newSession(dt, msg, isQuery, labelLimit, timestamp)
-				edm.sessionCollectorCh <- session
+				select {
+				case edm.sessionCollectorCh <- session:
+				case <-edm.ctx.Done():
+				}
 			}
 		case <-edm.reloadMinimiserConfigCh[minimiserID]:
 			edm.log.Info("runMinimiser: reloading config", "minimiser_id", minimiserID)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -77,6 +77,7 @@ type config struct {
 	DisableMQTT                   bool   `mapstructure:"disable-mqtt"`
 	DisableMQTTFilequeue          bool   `mapstructure:"disable-mqtt-filequeue"`
 	EnableManualParquetRotation   bool   `mapstructure:"enable-manual-parquet-rotation"`
+	PebbleSync                    bool   `mapstructure:"pebble-sync" reload:"true"`
 	InputUnix                     string `mapstructure:"input-unix" validate:"required_without_all=InputTCP InputTLS,excluded_with=InputTCP InputTLS"`
 	InputTCP                      string `mapstructure:"input-tcp" validate:"required_without_all=InputUnix InputTLS,excluded_with=InputUnix InputTLS"`
 	InputTLS                      string `mapstructure:"input-tls" validate:"required_without_all=InputUnix InputTCP,excluded_with=InputUnix InputTCP"`
@@ -1905,8 +1906,19 @@ func (wkd *wellKnownDomainsTracker) rotateTracker(edm *dnstapMinimiser, dawgFile
 	return prevWKD, nil
 }
 
+// seenQnameWriteOptions selects the pebble write options for seen-qname inserts.
+//
+// It returns [pebble.Sync] when conf.PebbleSync is set so writes are fsynced,
+// and [pebble.NoSync] otherwise.
+func seenQnameWriteOptions(conf config) *pebble.WriteOptions {
+	if conf.PebbleSync {
+		return pebble.Sync
+	}
+	return pebble.NoSync
+}
+
 // Check if we have already seen this qname since we started.
-func (edm *dnstapMinimiser) qnameSeen(msg *dns.Msg, seenQnameLRU *lru.Cache[string, struct{}], pdb *pebble.DB) bool {
+func (edm *dnstapMinimiser) qnameSeen(msg *dns.Msg, seenQnameLRU *lru.Cache[string, struct{}], pdb *pebble.DB, conf config) bool {
 	// NOTE: This looks like it might be a race (calling
 	// Get() followed by separate Add()) but since we want
 	// to keep often looked-up names in the cache we need to
@@ -1941,7 +1953,7 @@ func (edm *dnstapMinimiser) qnameSeen(msg *dns.Msg, seenQnameLRU *lru.Cache[stri
 
 	// If the key does not exist in pebble we insert it
 	if errors.Is(err, pebble.ErrNotFound) {
-		if err := pdb.Set([]byte(qname), []byte{}, pebble.Sync); err != nil {
+		if err := pdb.Set([]byte(qname), []byte{}, seenQnameWriteOptions(conf)); err != nil {
 			edm.log.Error("unable to insert key in pebble", "error", err)
 		}
 		return false
@@ -2118,7 +2130,7 @@ minimiserLoop:
 				continue
 			}
 
-			if !edm.qnameSeen(msg, seenQnameLRU, pdb) {
+			if !edm.qnameSeen(msg, seenQnameLRU, pdb, conf) {
 				if !startConf.DisableMQTT {
 					newQname := protocols.NewQnameEvent(msg, truncatedTimestamp)
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1552,7 +1552,7 @@ type dnstapMinimiser struct {
 	reloadMinimiserMutex          sync.RWMutex
 	reloadMinimiserConfigCh       []chan struct{}
 	reloadHistogramSenderConfigCh chan struct{}
-	seenQnameLocks                [seenQnameLockShards]sync.Mutex
+	seenQnameMutex                sync.Mutex
 }
 
 func createCryptopan(key string, salt string) (*cryptopan.Cryptopan, error) {
@@ -1918,32 +1918,17 @@ func seenQnameWriteOptions(conf config) *pebble.WriteOptions {
 	return pebble.NoSync
 }
 
-// seenQnameLockShards is the number of mutexes sharding qnameSeen by qname.
+// qnameSeen reports whether qname has been seen since startup, recording it (in
+// the in-memory LRU and in pebble) on first sight. writeOpts is the pebble write
+// option for the insert (see [seenQnameWriteOptions]); the caller derives it
+// once per config rather than passing the whole config down this hot path.
 //
-// It bounds [dnstapMinimiser.seenQnameLocks] and the modulus in
-// [seenQnameLockIndex], so both stay in sync.
-const seenQnameLockShards = 256
-
-// seenQnameLockIndex maps qname to a shard in [dnstapMinimiser.seenQnameLocks].
-//
-// It hashes qname with FNV-1a and reduces the result modulo
-// [seenQnameLockShards], so the returned index is always a valid offset into
-// the lock array.
-func seenQnameLockIndex(qname string) int {
-	var h uint32 = 2166136261
-	for i := 0; i < len(qname); i++ {
-		h ^= uint32(qname[i])
-		h *= 16777619
-	}
-	return int(h % seenQnameLockShards)
-}
-
-// Check if we have already seen this qname since we started.
-func (edm *dnstapMinimiser) qnameSeen(msg *dns.Msg, seenQnameLRU *lru.Cache[string, struct{}], pdb *pebble.DB, conf config) bool {
+// The check-and-record runs under edm.seenQnameMutex so concurrent minimiser
+// workers report any given qname as new at most once.
+func (edm *dnstapMinimiser) qnameSeen(msg *dns.Msg, seenQnameLRU *lru.Cache[string, struct{}], pdb *pebble.DB, writeOpts *pebble.WriteOptions) bool {
 	qname := strings.ToLower(msg.Question[0].Name)
-	seenLock := &edm.seenQnameLocks[seenQnameLockIndex(qname)]
-	seenLock.Lock()
-	defer seenLock.Unlock()
+	edm.seenQnameMutex.Lock()
+	defer edm.seenQnameMutex.Unlock()
 
 	_, ok := seenQnameLRU.Get(qname)
 	if ok {
@@ -1968,7 +1953,7 @@ func (edm *dnstapMinimiser) qnameSeen(msg *dns.Msg, seenQnameLRU *lru.Cache[stri
 
 	// If the key does not exist in pebble we insert it
 	if errors.Is(err, pebble.ErrNotFound) {
-		if err := pdb.Set([]byte(qname), []byte{}, seenQnameWriteOptions(conf)); err != nil {
+		if err := pdb.Set([]byte(qname), []byte{}, writeOpts); err != nil {
 			edm.log.Error("unable to insert key in pebble", "error", err)
 		}
 		return false
@@ -2046,6 +2031,9 @@ func (edm *dnstapMinimiser) runMinimiser(minimiserID int, wg *sync.WaitGroup, se
 
 	// conf is meant to be dynamically modified if the config changes at runtime
 	conf := edm.getConfig()
+	// Derived from conf once here (and re-derived on reload below) so the
+	// qnameSeen hot path takes a pointer instead of copying the whole config.
+	writeOpts := seenQnameWriteOptions(conf)
 
 minimiserLoop:
 	for {
@@ -2053,8 +2041,18 @@ minimiserLoop:
 		case frame := <-edm.inputChannel:
 			edm.promDnstapProcessed.Inc()
 			if err := proto.Unmarshal(frame, dt); err != nil {
-				edm.log.Error("dnstapMinimiser.runMinimiser: proto.Unmarshal() failed, returning", "error", err, "minimiser_id", minimiserID)
-				break minimiserLoop
+				edm.log.Error("dnstapMinimiser.runMinimiser: proto.Unmarshal() failed, skipping frame", "error", err, "minimiser_id", minimiserID)
+				continue
+			}
+			// Guard the hot-path dereferences (here and below: QueryAddress,
+			// clientIPIsIgnored) so a partially populated frame is dropped
+			// rather than panicking before parsePacket's own nil checks. A
+			// Message present but missing its required Type is already rejected
+			// by proto.Unmarshal above; the Type check here is belt-and-braces.
+			if dt.Message == nil || dt.Message.Type == nil {
+				edm.log.Error("dnstapMinimiser.runMinimiser: dnstap message or type missing, skipping frame", "minimiser_id", minimiserID)
+				edm.promDNSParseError.Inc()
+				continue
 			}
 
 			// Keep in mind that this outputs the unmodified dnstap
@@ -2069,15 +2067,6 @@ minimiserLoop:
 						edm.log.Error("unable to write to dnstap debug file", "error", err, "filename", debugDnstapFile.Name(), "minimiser_id", minimiserID)
 					}
 				}
-			}
-
-			// Guard the hot-path dereferences (here and below: QueryAddress,
-			// clientIPIsIgnored) so a partially populated frame is dropped
-			// rather than panicking before parsePacket's own nil checks.
-			if dt.Message == nil || dt.Message.Type == nil {
-				edm.log.Error("runMinimiser: dnstap message or type missing, dropping packet", "minimiser_id", minimiserID)
-				edm.promDNSParseError.Inc()
-				continue
 			}
 
 			isQuery := strings.HasSuffix(dnstap.Message_Type_name[int32(dt.Message.GetType())], "_QUERY")
@@ -2145,7 +2134,7 @@ minimiserLoop:
 				continue
 			}
 
-			if !edm.qnameSeen(msg, seenQnameLRU, pdb, conf) {
+			if !edm.qnameSeen(msg, seenQnameLRU, pdb, writeOpts) {
 				if !startConf.DisableMQTT {
 					newQname := protocols.NewQnameEvent(msg, truncatedTimestamp)
 
@@ -2178,6 +2167,7 @@ minimiserLoop:
 			}
 
 			conf = newConf
+			writeOpts = seenQnameWriteOptions(conf)
 		case <-edm.ctx.Done():
 			break minimiserLoop
 		}

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -888,10 +888,10 @@ func TestQnameSeen(t *testing.T) {
 
 	msg := new(dns.Msg)
 	msg.SetQuestion("Example.COM.", dns.TypeA)
-	if edm.qnameSeen(msg, cache, db, defaultTC.config) {
+	if edm.qnameSeen(msg, cache, db, seenQnameWriteOptions(defaultTC.config)) {
 		t.Fatal("first qnameSeen call returned true")
 	}
-	if !edm.qnameSeen(msg, cache, db, defaultTC.config) {
+	if !edm.qnameSeen(msg, cache, db, seenQnameWriteOptions(defaultTC.config)) {
 		t.Fatal("second qnameSeen call returned false")
 	}
 
@@ -899,13 +899,13 @@ func TestQnameSeen(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !edm.qnameSeen(msg, cache, db, defaultTC.config) {
+	if !edm.qnameSeen(msg, cache, db, seenQnameWriteOptions(defaultTC.config)) {
 		t.Fatal("qnameSeen did not find qname in pebble")
 	}
 
 	other := new(dns.Msg)
 	other.SetQuestion("other.example.", dns.TypeA)
-	_ = edm.qnameSeen(other, cache, db, defaultTC.config)
+	_ = edm.qnameSeen(other, cache, db, seenQnameWriteOptions(defaultTC.config))
 }
 
 func TestWellKnownDomainUpdatesAndRotation(t *testing.T) {
@@ -1151,7 +1151,7 @@ func TestQnameSeenLRUEviction(t *testing.T) {
 
 	first := new(dns.Msg)
 	first.SetQuestion("a.example.", dns.TypeA)
-	if edm.qnameSeen(first, cache, db, defaultTC.config) {
+	if edm.qnameSeen(first, cache, db, seenQnameWriteOptions(defaultTC.config)) {
 		t.Fatal("first qname unexpectedly already-seen")
 	}
 
@@ -1159,7 +1159,7 @@ func TestQnameSeenLRUEviction(t *testing.T) {
 	second.SetQuestion("b.example.", dns.TypeA)
 	// Adding the second distinct qname evicts the first from the LRU,
 	// exercising the evicted/promSeenQnameLRUEvicted.Inc() arm.
-	_ = edm.qnameSeen(second, cache, db, defaultTC.config)
+	_ = edm.qnameSeen(second, cache, db, seenQnameWriteOptions(defaultTC.config))
 	if cache.Len() != 1 {
 		t.Fatalf("cache len = %d, want 1 after eviction", cache.Len())
 	}
@@ -2573,6 +2573,9 @@ func TestRunMinimiserParseAndIgnoreFlows(t *testing.T) {
 	wg.Add(1)
 	go edm.runMinimiser(0, &wg, cache, db, nil, defaultLabelLimit, wkd)
 	edm.inputChannel <- []byte("not protobuf")
+	// Malformed frames are skipped, not fatal, so stop the minimiser
+	// explicitly to unblock the goroutine.
+	edm.stop()
 	wg.Wait()
 
 	edm = newTestDnstapMinimiser(t, defaultTC)

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -888,10 +888,10 @@ func TestQnameSeen(t *testing.T) {
 
 	msg := new(dns.Msg)
 	msg.SetQuestion("Example.COM.", dns.TypeA)
-	if edm.qnameSeen(msg, cache, db) {
+	if edm.qnameSeen(msg, cache, db, defaultTC.config) {
 		t.Fatal("first qnameSeen call returned true")
 	}
-	if !edm.qnameSeen(msg, cache, db) {
+	if !edm.qnameSeen(msg, cache, db, defaultTC.config) {
 		t.Fatal("second qnameSeen call returned false")
 	}
 
@@ -899,13 +899,13 @@ func TestQnameSeen(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !edm.qnameSeen(msg, cache, db) {
+	if !edm.qnameSeen(msg, cache, db, defaultTC.config) {
 		t.Fatal("qnameSeen did not find qname in pebble")
 	}
 
 	other := new(dns.Msg)
 	other.SetQuestion("other.example.", dns.TypeA)
-	_ = edm.qnameSeen(other, cache, db)
+	_ = edm.qnameSeen(other, cache, db, defaultTC.config)
 }
 
 func TestWellKnownDomainUpdatesAndRotation(t *testing.T) {
@@ -1151,7 +1151,7 @@ func TestQnameSeenLRUEviction(t *testing.T) {
 
 	first := new(dns.Msg)
 	first.SetQuestion("a.example.", dns.TypeA)
-	if edm.qnameSeen(first, cache, db) {
+	if edm.qnameSeen(first, cache, db, defaultTC.config) {
 		t.Fatal("first qname unexpectedly already-seen")
 	}
 
@@ -1159,7 +1159,7 @@ func TestQnameSeenLRUEviction(t *testing.T) {
 	second.SetQuestion("b.example.", dns.TypeA)
 	// Adding the second distinct qname evicts the first from the LRU,
 	// exercising the evicted/promSeenQnameLRUEvicted.Inc() arm.
-	_ = edm.qnameSeen(second, cache, db)
+	_ = edm.qnameSeen(second, cache, db, defaultTC.config)
 	if cache.Len() != 1 {
 		t.Fatalf("cache len = %d, want 1 after eviction", cache.Len())
 	}


### PR DESCRIPTION
Combines four coupled `runMinimiser`/`qnameSeen` fixes (they all touch the same code + the shared `run_minimiser_test.go`, so they must merge together) into one PR — supersedes #193, #182, #187, #178.

- **#193** — `pebble-sync` config switch (NoSync by default, opt-in Sync) via `seenQnameWriteOptions`; `qnameSeen` gains a `conf` param.
- **#182** — per-qname sharded locking in `qnameSeen` so concurrent workers don't each treat a qname as first-seen.
- **#187** — `runMinimiser` wraps the `sessionCollectorCh` send in `select { … case <-ctx.Done(): }` so shutdown isn't blocked.
- **#178** — `runMinimiser` skips malformed frames (`continue`, not `break`) + nil `Message`/`Type` guards.

Each fix is a separate commit; the shared test file is merged with no duplicate helpers. Verified: `go build`, `go vet`, `staticcheck`, `golangci-lint`, `go test -race ./...` all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag to control durable writes for DNS name tracking.

* **Bug Fixes**
  * Malformed/partial DNS frames are now skipped instead of halting processing.
  * Session collection respects shutdown and unblocks promptly during exit.

* **Tests**
  * Added unit tests for name-tracking, concurrency, shutdown behavior, and malformed-frame handling; added a benchmark for qname-seen hot path.

* **Chores**
  * Made a Prometheus client dependency a direct module requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->