### PR TITLE
feat(runner): collector shutdown-flush + safe DAWG reload + atomic lock-free reload

### DIFF
--- a/pkg/runner/atomic_reload_test.go
+++ b/pkg/runner/atomic_reload_test.go
@@ -1,0 +1,404 @@
+package runner
+
+import (
+	"io"
+	"log/slog"
+	"net/netip"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	dnstap "github.com/dnstap/golang-dnstap"
+	"github.com/miekg/dns"
+)
+
+// The tests in this file exercise the lock-free reload paths in runner.go:
+// ignored-IP and ignored-question lookups read
+// atomic.Pointer snapshots on the hot path with no mutex, and reload
+// writers atomic.Store fresh values. They are designed to fail under
+// `go test -race` if a future change accidentally reintroduces unsynchronised
+// access - for example, by replacing the atomic.Pointer with a bare
+// pointer field.
+//
+// They do *not* try to assert what value a reader sees mid-reload (that
+// is intentionally racy at the value level, just not at the memory-model
+// level); they only assert that the readers and the writer can run
+// concurrently without panicking and without the race detector flagging
+// the access.
+
+// TestConcurrentIgnoredClientIPsReload reloads the ignored client IP set
+// while a fleet of readers calls clientIPIsIgnored. Each reader uses a
+// mix of IPv4 and IPv6 addresses, including some that may or may not be
+// in the set depending on which reload was most recent.
+//
+// Run under -race to catch any unsynchronised access to the IPSet pointer
+// or the CIDR count.
+func TestConcurrentIgnoredClientIPsReload(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	edm, err := newDnstapMinimiser(logger, defaultTC)
+	if err != nil {
+		t.Fatalf("newDnstapMinimiser: %s", err)
+	}
+	t.Cleanup(func() { cleanupTestMinimiser(edm) })
+
+	// Prime the set so readers don't all hit the early-return nil path.
+	edm.conf.IgnoredClientIPsFile = "testdata/ignored-client-ips.valid1"
+	if err := edm.setIgnoredClientIPs(); err != nil {
+		t.Fatalf("initial setIgnoredClientIPs: %s", err)
+	}
+
+	// We alternate between two valid files plus the empty file (which
+	// stores nil), so readers exercise both the populated- and nil-
+	// snapshot paths.
+	files := []string{
+		"testdata/ignored-client-ips.valid1",
+		"testdata/ignored-client-ips.valid2",
+		"testdata/ignored-client-ips.empty",
+	}
+
+	addrs := []netip.Addr{
+		netip.MustParseAddr("127.0.0.1"),
+		netip.MustParseAddr("127.0.0.3"),
+		netip.MustParseAddr("10.10.8.5"),
+		netip.MustParseAddr("198.51.100.10"),
+		netip.MustParseAddr("::1"),
+		netip.MustParseAddr("::3"),
+		netip.MustParseAddr("2001:db8:0010:0011::10"),
+	}
+
+	var (
+		stop atomic.Bool
+		wg   sync.WaitGroup
+	)
+
+	// Start readers. Each reader spins clientIPIsIgnored across the
+	// address mix. We discard the result - what matters is that the call
+	// returns and -race observes no unsynchronised reads.
+	const numReaders = 8
+	wg.Add(numReaders)
+	for r := range numReaders {
+		go func(seed int) {
+			defer wg.Done()
+			i := seed
+			for !stop.Load() {
+				addr := addrs[i%len(addrs)]
+				dt := &dnstap.Dnstap{
+					Message: &dnstap.Message{
+						QueryAddress: addr.AsSlice(),
+					},
+				}
+				_ = edm.clientIPIsIgnored(dt)
+				_ = edm.getNumIgnoredClientCIDRs()
+				i++
+			}
+		}(r)
+	}
+
+	// Single writer: rotate the configured file and call
+	// setIgnoredClientIPs. We do a fixed number of rotations rather than
+	// running for a wall-clock duration so the test is deterministic
+	// under load and slow CI runners.
+	const rotations = 200
+	for i := range rotations {
+		edm.conf.IgnoredClientIPsFile = files[i%len(files)]
+		if err := edm.setIgnoredClientIPs(); err != nil {
+			stop.Store(true)
+			wg.Wait()
+			t.Fatalf("rotation %d: setIgnoredClientIPs(%s): %s", i, edm.conf.IgnoredClientIPsFile, err)
+		}
+	}
+
+	stop.Store(true)
+	wg.Wait()
+}
+
+// TestConcurrentIgnoredQuestionsReload mirrors the IP test above but for
+// the DAWG-backed ignored-question set, which is stored in an
+// atomic.Pointer[dawgFinderHolder]. The wrapper exists because dawg.Finder
+// is an interface and atomic.Pointer wants a concrete type - see the
+// design note on the dnstapMinimiser struct in runner.go.
+//
+// As with the IP test the assertion is purely "no race, no panic". A
+// future change that, say, reintroduced ignoredQuestionsMutex without
+// updating readers would either deadlock (test would time out) or race
+// (race detector would fail).
+func TestConcurrentIgnoredQuestionsReload(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	edm, err := newDnstapMinimiser(logger, defaultTC)
+	if err != nil {
+		t.Fatalf("newDnstapMinimiser: %s", err)
+	}
+	t.Cleanup(func() { cleanupTestMinimiser(edm) })
+
+	// Prime so readers exercise the non-nil snapshot branch initially.
+	edm.conf.IgnoredQuestionNamesFile = "testdata/ignored-question-names.valid1.dawg"
+	if err := edm.setIgnoredQuestionNames(); err != nil {
+		t.Fatalf("initial setIgnoredQuestionNames: %s", err)
+	}
+
+	files := []string{
+		"testdata/ignored-question-names.valid1.dawg",
+		"testdata/ignored-question-names.valid2.dawg",
+		"testdata/ignored-question-names.empty.dawg", // empty maps to nil holder
+	}
+
+	questions := []string{
+		"example.com.",
+		"www.example.net.",
+		"www.example.org.",
+		"www.example.edu.",
+		"unrelated.invalid.",
+	}
+
+	var (
+		stop atomic.Bool
+		wg   sync.WaitGroup
+	)
+
+	const numReaders = 8
+	wg.Add(numReaders)
+	for r := range numReaders {
+		go func(seed int) {
+			defer wg.Done()
+			i := seed
+			for !stop.Load() {
+				m := new(dns.Msg)
+				m.SetQuestion(questions[i%len(questions)], dns.TypeA)
+				_ = edm.questionIsIgnored(m)
+				i++
+			}
+		}(r)
+	}
+
+	const rotations = 200
+	for i := range rotations {
+		edm.conf.IgnoredQuestionNamesFile = files[i%len(files)]
+		if err := edm.setIgnoredQuestionNames(); err != nil {
+			stop.Store(true)
+			wg.Wait()
+			t.Fatalf("rotation %d: setIgnoredQuestionNames(%s): %s", i, edm.conf.IgnoredQuestionNamesFile, err)
+		}
+	}
+
+	stop.Store(true)
+	wg.Wait()
+}
+
+// TestConcurrentSetCryptopanReload exercises the lock-free Crypto-PAn
+// rotation path: workers Load the cryptopan pointer and the generation
+// counter on the hot path, while a writer rotates the key. The atomic
+// store for the pointer plus the atomic add for the generation must
+// synchronise so a worker that sees the new generation also observes the
+// new pointer (otherwise it would Purge its cache and then immediately
+// re-fill it from the *old* cryptopan, defeating the rotation).
+//
+// We don't assert the exact ordering here - that is what -race plus the
+// memory-model guarantees of atomic.Store/atomic.Add are for. What we
+// do assert is that the cryptopan pointer is never observed nil mid-run,
+// and that the final generation reflects every successful rotation.
+func TestConcurrentSetCryptopanReload(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	edm, err := newDnstapMinimiser(logger, defaultTC)
+	if err != nil {
+		t.Fatalf("newDnstapMinimiser: %s", err)
+	}
+	t.Cleanup(func() { cleanupTestMinimiser(edm) })
+
+	var (
+		stop atomic.Bool
+		wg   sync.WaitGroup
+	)
+
+	const numReaders = 4
+	wg.Add(numReaders)
+	for range numReaders {
+		go func() {
+			defer wg.Done()
+			for !stop.Load() {
+				cpn := edm.cryptopan.Load()
+				gen := edm.cryptopanGen.Load()
+				// The minimiser construction installs an initial
+				// instance and the writer below only ever stores
+				// non-nil pointers via setCryptopan - so observing nil
+				// at any point is a contract violation.
+				if cpn == nil {
+					t.Errorf("cryptopan pointer observed as nil at gen=%d", gen)
+					return
+				}
+			}
+		}()
+	}
+
+	// Rotate the cryptopan instance several times. setCryptopan is
+	// expensive (argon2 KDF, ~100–200ms per call) so we keep the count
+	// modest - the readers still spin tens of thousands of Loads in
+	// that window, which is plenty for the race detector to catch any
+	// regression. The salt stays constant; only the key changes so each
+	// call installs a distinct instance.
+	const rotations = 20
+	for i := range rotations {
+		key := "rotation-key-"
+		// Avoid a strconv import dependency for this test by composing
+		// short keys. The exact value doesn't matter - only that it
+		// changes each iteration.
+		key += string(rune('a' + (i % 26)))
+		key += string(rune('a' + ((i / 26) % 26)))
+		if err := edm.setCryptopan(key, defaultTC.CryptopanKeySalt, defaultTC.CryptopanAddressEntries); err != nil {
+			stop.Store(true)
+			wg.Wait()
+			t.Fatalf("rotation %d: setCryptopan: %s", i, err)
+		}
+	}
+
+	stop.Store(true)
+	wg.Wait()
+
+	// After the writer has finished the generation must reflect every
+	// successful rotation - strictly monotonic, no skipped/dropped
+	// increments. The +1 accounts for the setCryptopan call inside
+	// newDnstapMinimiser.
+	wantGen := uint64(rotations + 1)
+	if got := edm.cryptopanGen.Load(); got != wantGen {
+		t.Fatalf("final cryptopanGen have: %d, want: %d", got, wantGen)
+	}
+}
+
+// TestQuestionIsIgnoredMultipleQuestions documents the explicit "any
+// matches" policy in questionIsIgnored when a DNS message carries more
+// than one question. The runner.go comment states: "if there happens to
+// be multiple questions in the packet we consider the message ignored if
+// any of them matches" - but no existing test exercises a multi-question
+// message, so a future refactor that, say, only inspected msg.Question[0]
+// would silently regress with no test failure.
+//
+// In practice DNS messages with QDCOUNT > 1 are extremely rare and most
+// recursors reject them, but the code intentionally handles the case;
+// this test pins the behaviour.
+func TestQuestionIsIgnoredMultipleQuestions(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	edm, err := newDnstapMinimiser(logger, defaultTC)
+	if err != nil {
+		t.Fatalf("newDnstapMinimiser: %s", err)
+	}
+	t.Cleanup(func() { cleanupTestMinimiser(edm) })
+
+	edm.conf.IgnoredQuestionNamesFile = "testdata/ignored-question-names.valid1.dawg"
+	if err := edm.setIgnoredQuestionNames(); err != nil {
+		t.Fatalf("setIgnoredQuestionNames: %s", err)
+	}
+
+	// example.com. is in valid1.dawg as an exact match (see existing
+	// TestIgnoredQuestionNamesValid). We pair it with a name that is NOT
+	// ignored, in both orders, to make sure the loop scans past
+	// non-matching questions and does not short-circuit on the first
+	// entry.
+	tests := []struct {
+		name      string
+		questions []string
+		want      bool
+	}{
+		{
+			name:      "single non-matching question",
+			questions: []string{"unrelated.invalid."},
+			want:      false,
+		},
+		{
+			name:      "matching question first",
+			questions: []string{"example.com.", "unrelated.invalid."},
+			want:      true,
+		},
+		{
+			name:      "matching question second",
+			questions: []string{"unrelated.invalid.", "example.com."},
+			want:      true,
+		},
+		{
+			name:      "no matches in any of multiple questions",
+			questions: []string{"unrelated.invalid.", "another.invalid."},
+			want:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := new(dns.Msg)
+			// SetQuestion only handles a single question; build the
+			// slice directly to model an unusual multi-question packet.
+			m.Question = make([]dns.Question, len(tc.questions))
+			for i, q := range tc.questions {
+				m.Question[i] = dns.Question{
+					Name:   q,
+					Qtype:  dns.TypeA,
+					Qclass: dns.ClassINET,
+				}
+			}
+
+			if got := edm.questionIsIgnored(m); got != tc.want {
+				t.Fatalf("questionIsIgnored(%v) have: %t, want: %t", tc.questions, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClientIPIsIgnoredEmptyQueryAddress documents the deliberate
+// "fail-closed" behaviour for unparseable QueryAddress slices when an
+// ignore list is active: the packet is treated as ignored and an error
+// counter is incremented. Existing TestIgnoredClientIPsInvalidClient
+// covers a 5-byte slice; this complements it with the nil and empty-slice
+// cases, which take the same code path through netip.AddrFromSlice but
+// are easy to overlook in future refactors that try to "optimise" the
+// nil check.
+//
+// The behaviour matters because production EDM applies the ignore list
+// before any further parsing - silently allowing a packet with no
+// QueryAddress through would defeat operator policy.
+func TestClientIPIsIgnoredEmptyQueryAddress(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	edm, err := newDnstapMinimiser(logger, defaultTC)
+	if err != nil {
+		t.Fatalf("newDnstapMinimiser: %s", err)
+	}
+	t.Cleanup(func() { cleanupTestMinimiser(edm) })
+
+	// Active list - exercise the fail-closed path.
+	edm.conf.IgnoredClientIPsFile = "testdata/ignored-client-ips.valid1"
+	if err := edm.setIgnoredClientIPs(); err != nil {
+		t.Fatalf("setIgnoredClientIPs: %s", err)
+	}
+
+	cases := []struct {
+		name string
+		addr []byte
+	}{
+		{"nil QueryAddress", nil},
+		{"zero-length QueryAddress", []byte{}},
+		// already covered by TestIgnoredClientIPsInvalidClient but
+		// included here for symmetry / regression-safety in this file.
+		{"odd-length QueryAddress", make([]byte, 7)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dt := &dnstap.Dnstap{Message: &dnstap.Message{QueryAddress: tc.addr}}
+			if got := edm.clientIPIsIgnored(dt); !got {
+				t.Fatalf("with active ignore list: have: %t, want: true (fail-closed)", got)
+			}
+		})
+	}
+
+	// With NO active list, an unparseable QueryAddress must NOT be
+	// treated as ignored - the early-return on a nil ipset is what
+	// allows the rest of the pipeline to handle (or log) the malformed
+	// packet itself rather than silently dropping it.
+	edm.conf.IgnoredClientIPsFile = "testdata/ignored-client-ips.empty"
+	if err := edm.setIgnoredClientIPs(); err != nil {
+		t.Fatalf("setIgnoredClientIPs(empty): %s", err)
+	}
+	for _, tc := range cases {
+		t.Run("inactive/"+tc.name, func(t *testing.T) {
+			dt := &dnstap.Dnstap{Message: &dnstap.Message{QueryAddress: tc.addr}}
+			if got := edm.clientIPIsIgnored(dt); got {
+				t.Fatalf("with no ignore list: have: %t, want: false", got)
+			}
+		})
+	}
+}

--- a/pkg/runner/cryptopan_extra_test.go
+++ b/pkg/runner/cryptopan_extra_test.go
@@ -1,0 +1,125 @@
+package runner
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// TestSetCryptopanBumpsGeneration verifies the contract that runMinimiser
+// workers rely on: every successful setCryptopan call must increment
+// edm.cryptopanGen by exactly one and atomic.Store a new cryptopan
+// pointer. Workers compare cryptopanGen against their last-seen value to
+// know when to Purge their local Crypto-PAn cache; if the generation
+// didn't strictly advance on each rotation, stale entries from the
+// previous key would silently leak through.
+func TestSetCryptopanBumpsGeneration(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	edm, err := newDnstapMinimiser(logger, defaultTC)
+	if err != nil {
+		t.Fatalf("unable to setup edm: %s", err)
+	}
+	t.Cleanup(func() { cleanupTestMinimiser(edm) })
+
+	// newDnstapMinimiser called setCryptopan once during construction; the
+	// generation we observe here is therefore the post-construction
+	// baseline, not zero. We only care about strict monotonic advancement
+	// per call, so capture the baseline and compare deltas.
+	baselineGen := edm.cryptopanGen.Load()
+	baselinePtr := edm.cryptopan.Load()
+	if baselinePtr == nil {
+		t.Fatalf("cryptopan pointer should be non-nil after newDnstapMinimiser")
+	}
+	prevPtr := baselinePtr
+
+	const rotations = 5
+	for i := 1; i <= rotations; i++ {
+		// Use a different key each time so we'd notice if the cryptopan
+		// pointer was being reused (cryptopan.New produces a new instance
+		// per call, so identical-key calls also produce distinct pointers
+		// - but varying the key catches accidental short-circuit
+		// optimisations more obviously).
+		key := "rotation-key-" + string(rune('0'+i))
+		if err := edm.setCryptopan(key, defaultTC.CryptopanKeySalt, defaultTC.CryptopanAddressEntries); err != nil {
+			t.Fatalf("rotation %d: setCryptopan failed: %s", i, err)
+		}
+
+		gotGen := edm.cryptopanGen.Load()
+		wantGen := baselineGen + uint64(i)
+		if gotGen != wantGen {
+			t.Fatalf("rotation %d: cryptopanGen have: %d, want: %d", i, gotGen, wantGen)
+		}
+
+		gotPtr := edm.cryptopan.Load()
+		if gotPtr == nil {
+			t.Fatalf("rotation %d: cryptopan pointer should not be nil", i)
+		}
+		// Compare against the previous rotation (not just the baseline) so a
+		// rotation that reuses the immediately prior pointer is also caught.
+		if gotPtr == prevPtr {
+			t.Fatalf("rotation %d: cryptopan pointer was not replaced (still equal to the previous rotation's pointer)", i)
+		}
+		prevPtr = gotPtr
+	}
+}
+
+// TestSetCryptopanCacheEntriesArgumentIgnored documents (and locks in) that
+// the cacheEntries argument is a no-op for cache sizing: caches are owned
+// per-worker by runMinimiser, and setCryptopan only swaps the cryptopan
+// instance and bumps the generation. If a future change accidentally
+// re-introduced shared cache state on setCryptopan it would re-introduce the
+// contention this design avoids, so we pin the contract here.
+func TestSetCryptopanCacheEntriesArgumentIgnored(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	edm, err := newDnstapMinimiser(logger, defaultTC)
+	if err != nil {
+		t.Fatalf("unable to setup edm: %s", err)
+	}
+	t.Cleanup(func() { cleanupTestMinimiser(edm) })
+
+	// Wildly different cacheEntries values - including 0 (the sentinel that
+	// disables the per-worker cache) and a very large value - must all behave
+	// the same from setCryptopan's perspective: bump generation, swap pointer,
+	// do not touch any per-worker cache state (there is none on edm itself).
+	for _, n := range []int{0, 1, 1_000, 1_000_000} {
+		genBefore := edm.cryptopanGen.Load()
+		err := edm.setCryptopan(defaultTC.CryptopanKey, defaultTC.CryptopanKeySalt, n)
+		if err != nil {
+			t.Fatalf("setCryptopan(cacheEntries=%d) failed: %s", n, err)
+		}
+		if got := edm.cryptopanGen.Load(); got != genBefore+1 {
+			t.Fatalf("setCryptopan(cacheEntries=%d): gen have: %d, want: %d", n, got, genBefore+1)
+		}
+	}
+}
+
+// TestGetCryptopanAESKeyDeterministic locks in the key-derivation contract
+// that operators depend on: identical (key, salt) must produce identical
+// AES bytes across runs and process restarts (i.e. argon2 is deterministic
+// for a given parameter set). Operators rely on this so that on-disk data
+// pseudonymised before a restart can still be correlated against data
+// pseudonymised after - provided the configured key/salt did not change.
+func TestGetCryptopanAESKeyDeterministic(t *testing.T) {
+	const key = "operator-key"
+	const salt = "operator-salt-aabbccdd"
+
+	first := getCryptopanAESKey(key, salt)
+	second := getCryptopanAESKey(key, salt)
+
+	if len(first) != 32 {
+		t.Fatalf("aes key length have: %d, want: 32", len(first))
+	}
+	if string(first) != string(second) {
+		t.Fatalf("getCryptopanAESKey not deterministic for the same input")
+	}
+
+	// And differing inputs must produce different keys, otherwise the
+	// derivation would be pointless. We don't audit the Argon2 strength
+	// here - only that two trivially distinct inputs disagree.
+	if string(first) == string(getCryptopanAESKey(key+"!", salt)) {
+		t.Fatalf("getCryptopanAESKey returned same bytes for differing keys")
+	}
+	if string(first) == string(getCryptopanAESKey(key, salt+"!")) {
+		t.Fatalf("getCryptopanAESKey returned same bytes for differing salts")
+	}
+}

--- a/pkg/runner/data_collector_test.go
+++ b/pkg/runner/data_collector_test.go
@@ -1,0 +1,156 @@
+package runner
+
+import (
+	"io"
+	"log/slog"
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/smhanov/dawg"
+	"github.com/spaolacci/murmur3"
+)
+
+func TestDataCollectorFlushesPendingDataOnShutdown(t *testing.T) {
+	edm, wkdTracker := newDataCollectorTestFixture(t, "example.com.")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go edm.dataCollector(&wg, wkdTracker, "unused-in-shutdown-test.dawg")
+
+	serverID := "serverID"
+	edm.sessionCollectorCh <- &sessionData{ServerID: &serverID}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeA)
+	ip := netip.MustParseAddr("198.51.100.10")
+	dawgIndex, suffixMatch, dawgModTime := wkdTracker.lookup(msg)
+	wkdTracker.updateCh <- wkdUpdate{
+		dawgIndex:   dawgIndex,
+		suffixMatch: suffixMatch,
+		dawgModTime: dawgModTime,
+		histogramData: histogramData{
+			ACount:  1,
+			OKCount: 1,
+		},
+		hllHash: murmur3.Sum64(ip.AsSlice()),
+		ip:      ip,
+	}
+
+	close(wkdTracker.stop)
+	waitOrFail(t, &wg, 2*time.Second, "dataCollector did not exit after stop")
+
+	ps, ok := <-edm.sessionWriterCh
+	if !ok {
+		t.Fatal("sessionWriterCh closed without flushing pending session data")
+	}
+	if len(ps.sessions) != 1 {
+		t.Fatalf("flushed sessions have: %d, want: 1", len(ps.sessions))
+	}
+	if ps.startTime.IsZero() {
+		t.Fatal("flushed sessions should carry the collector interval start")
+	}
+	if ps.rotationTime.Before(ps.startTime) {
+		t.Fatalf("session interval is inverted: start=%s stop=%s", ps.startTime, ps.rotationTime)
+	}
+
+	prevWKD, ok := <-edm.histogramWriterCh
+	if !ok {
+		t.Fatal("histogramWriterCh closed without flushing pending histogram data")
+	}
+	if len(prevWKD.m) != 1 {
+		t.Fatalf("flushed histogram domains have: %d, want: 1", len(prevWKD.m))
+	}
+	got := prevWKD.m[dawgIndex]
+	if got == nil {
+		t.Fatalf("flushed histogram missing DAWG index %d", dawgIndex)
+	}
+	if got.ACount != 1 || got.OKCount != 1 {
+		t.Fatalf("flushed histogram counts have A=%d OK=%d, want A=1 OK=1", got.ACount, got.OKCount)
+	}
+	if prevWKD.startTime.IsZero() {
+		t.Fatal("flushed histogram should carry the collector interval start")
+	}
+	if prevWKD.rotationTime.Before(prevWKD.startTime) {
+		t.Fatalf("histogram interval is inverted: start=%s stop=%s", prevWKD.startTime, prevWKD.rotationTime)
+	}
+}
+
+func TestDataCollectorAdvancesSessionIntervalWhenRotationFails(t *testing.T) {
+	edm, wkdTracker := newDataCollectorTestFixture(t, "example.com.")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	// A missing dawg file makes rotateTracker fail, exercising the path
+	// where session data is flushed but histogram rotation errors out.
+	go edm.dataCollector(&wg, wkdTracker, "missing-dawg-file.dawg")
+
+	firstServerID := "first"
+	edm.sessionCollectorCh <- &sessionData{ServerID: &firstServerID}
+
+	rotationTime := time.Now().UTC()
+	done := make(chan error, 1)
+	edm.parquetRotationRequestCh <- parquetRotationRequest{
+		rotationTime: rotationTime,
+		done:         done,
+	}
+	if err := <-done; err == nil {
+		t.Fatal("manual rotation with missing dawg file should fail")
+	}
+
+	// The failed rotation still flushed the first session interval.
+	first, ok := <-edm.sessionWriterCh
+	if !ok {
+		t.Fatal("sessionWriterCh closed without flushing the first session interval")
+	}
+	if len(first.sessions) != 1 {
+		t.Fatalf("first flushed sessions have: %d, want: 1", len(first.sessions))
+	}
+	if !first.rotationTime.Equal(rotationTime) {
+		t.Fatalf("first flushed sessions stop at %s, want %s", first.rotationTime, rotationTime)
+	}
+
+	secondServerID := "second"
+	edm.sessionCollectorCh <- &sessionData{ServerID: &secondServerID}
+
+	close(wkdTracker.stop)
+	waitOrFail(t, &wg, 2*time.Second, "dataCollector did not exit after stop")
+
+	// The shutdown flush must start the second session interval at the
+	// failed rotation's time, proving the session boundary advanced even
+	// though histogram rotation failed.
+	second, ok := <-edm.sessionWriterCh
+	if !ok {
+		t.Fatal("sessionWriterCh closed without flushing the second session interval")
+	}
+	if len(second.sessions) != 1 {
+		t.Fatalf("second flushed sessions have: %d, want: 1", len(second.sessions))
+	}
+	if !second.startTime.Equal(rotationTime) {
+		t.Fatalf("second session interval starts at %s, want %s", second.startTime, rotationTime)
+	}
+}
+
+func newDataCollectorTestFixture(t *testing.T, knownDomains ...string) (*dnstapMinimiser, *wellKnownDomainsTracker) {
+	t.Helper()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	edm, err := newDnstapMinimiser(logger, defaultTC)
+	if err != nil {
+		t.Fatalf("newDnstapMinimiser: %s", err)
+	}
+	t.Cleanup(edm.stop)
+
+	dBuilder := dawg.New()
+	for _, domain := range knownDomains {
+		dBuilder.Add(domain)
+	}
+	wkdTracker, err := newWellKnownDomainsTracker(dBuilder.Finish(), time.Unix(0, 0))
+	if err != nil {
+		t.Fatalf("newWellKnownDomainsTracker: %s", err)
+	}
+
+	return edm, wkdTracker
+}

--- a/pkg/runner/data_collector_test.go
+++ b/pkg/runner/data_collector_test.go
@@ -141,7 +141,7 @@ func newDataCollectorTestFixture(t *testing.T, knownDomains ...string) (*dnstapM
 	if err != nil {
 		t.Fatalf("newDnstapMinimiser: %s", err)
 	}
-	t.Cleanup(edm.stop)
+	t.Cleanup(func() { cleanupTestMinimiser(edm) })
 
 	dBuilder := dawg.New()
 	for _, domain := range knownDomains {

--- a/pkg/runner/ignorechecks_bench_test.go
+++ b/pkg/runner/ignorechecks_bench_test.go
@@ -1,0 +1,39 @@
+package runner
+
+import (
+	"net/netip"
+	"testing"
+
+	dnstap "github.com/dnstap/golang-dnstap"
+	"github.com/miekg/dns"
+)
+
+// BenchmarkIgnoreChecksParallel measures the per-packet ignore-list read path
+// (clientIPIsIgnored + questionIsIgnored) under concurrent minimiser workers.
+//
+// These reads are taken on every packet by every worker. This benchmark
+// isolates the synchronisation cost of that read path — the ignore lists are
+// left unset, so each call is just the snapshot read plus a nil check, which is
+// exactly the part this code controls (an atomic.Pointer load versus, in the
+// previous design, a RWMutex.RLock). Run with -cpu=1,8,... to see how it scales
+// across workers; the lock-free version should stay flat while a reader-lock
+// version degrades as cores (and thus reader-lock contention) increase.
+func BenchmarkIgnoreChecksParallel(b *testing.B) {
+	edm := newTestDnstapMinimiser(b, defaultTC)
+
+	dt := &dnstap.Dnstap{
+		Message: &dnstap.Message{
+			QueryAddress: netip.MustParseAddr("198.51.100.20").AsSlice(),
+		},
+	}
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeA)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			edm.clientIPIsIgnored(dt)
+			edm.questionIsIgnored(msg)
+		}
+	})
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1871,6 +1871,7 @@ func (wkd *wellKnownDomainsTracker) sendUpdate(ipBytes []byte, msg *dns.Msg, daw
 func (wkd *wellKnownDomainsTracker) rotateTracker(edm *dnstapMinimiser, dawgFile string, rotationTime time.Time) (*wellKnownDomainsData, error) {
 	dawgFileChanged := false
 	var dawgFinder dawg.Finder
+	var dawgModTime time.Time
 
 	fileInfo, err := os.Stat(dawgFile)
 	if err != nil {
@@ -1878,9 +1879,9 @@ func (wkd *wellKnownDomainsTracker) rotateTracker(edm *dnstapMinimiser, dawgFile
 	}
 
 	if fileInfo.ModTime() != wkd.dawgModTime {
-		dawgFinder, err = dawg.Load(dawgFile)
+		dawgFinder, dawgModTime, err = loadDawgFile(dawgFile)
 		if err != nil {
-			return nil, fmt.Errorf("rotateTracker: dawg.Load(): %w", err)
+			return nil, fmt.Errorf("rotateTracker: loadDawgFile(): %w", err)
 		}
 		dawgFileChanged = true
 		edm.log.Info("dawg file modification changed, will reload file", "prev_time", wkd.dawgModTime, "cur_time", fileInfo.ModTime())
@@ -1895,7 +1896,7 @@ func (wkd *wellKnownDomainsTracker) rotateTracker(edm *dnstapMinimiser, dawgFile
 	wkd.m = map[int]*histogramData{}
 	if dawgFileChanged {
 		wkd.dawgFinder = dawgFinder
-		wkd.dawgModTime = fileInfo.ModTime()
+		wkd.dawgModTime = dawgModTime
 		prevWKD.dawgIsRotated = true
 	}
 	wkd.mutex.Unlock()

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -99,7 +100,7 @@ type config struct {
 	MQTTKeepalive                 uint16 `mapstructure:"mqtt-keepalive" validate:"required_without=DisableMQTT"`
 	MQTTSignWorkers               int    `mapstructure:"mqtt-sign-workers"`
 	QnameSeenEntries              int    `mapstructure:"qname-seen-entries"`
-	CryptopanAddressEntries       int    `mapstructure:"cryptopan-address-entries" reload:"true"`
+	CryptopanAddressEntries       int    `mapstructure:"cryptopan-address-entries"`
 	NewQnameBuffer                int    `mapstructure:"newqname-buffer"`
 	HTTPCAFile                    string `mapstructure:"http-ca-file"`
 	HTTPSigningKeyFile            string `mapstructure:"http-signing-key-file" validate:"required_without=DisableHistogramSender"`
@@ -443,14 +444,15 @@ func getCryptopanAESKey(key string, salt string) []byte {
 }
 
 func (edm *dnstapMinimiser) setCryptopan(key string, salt string, cacheEntries int) error {
-	var cpnCache *lru.Cache[netip.Addr, netip.Addr]
-	var err error
-
-	if cacheEntries != 0 {
-		cpnCache, err = lru.New[netip.Addr, netip.Addr](cacheEntries)
-		if err != nil {
-			return fmt.Errorf("setCryptopan: unable to create cache: %w", err)
-		}
+	// cacheEntries is the per-worker LRU size, validated here so a bad config
+	// value surfaces at load time instead of crashing a worker when it builds
+	// its LRU. The caches themselves are owned by each minimiser worker (see
+	// runMinimiser) and are sized once at worker start; setCryptopan only
+	// installs the cryptopan instance and signals workers to purge their caches
+	// on the next call. Changing cryptopan-address-entries therefore takes
+	// effect only on restart, which is why that field is not reloadable.
+	if cacheEntries < 0 {
+		return fmt.Errorf("setCryptopan: invalid cache size %d", cacheEntries)
 	}
 
 	cpn, err := createCryptopan(key, salt)
@@ -458,10 +460,8 @@ func (edm *dnstapMinimiser) setCryptopan(key string, salt string, cacheEntries i
 		return fmt.Errorf("setCryptopan: unable to create cryptopan: %w", err)
 	}
 
-	edm.cryptopanMutex.Lock()
-	edm.cryptopan = cpn
-	edm.cryptopanCache = cpnCache
-	edm.cryptopanMutex.Unlock()
+	edm.cryptopan.Store(cpn)
+	edm.cryptopanGen.Add(1)
 
 	return nil
 }
@@ -524,8 +524,7 @@ func configUpdater(viperNotifyCh chan fsnotify.Event, edm *dnstapMinimiser) {
 		}
 
 		if oldConf.CryptopanKey != conf.CryptopanKey ||
-			oldConf.CryptopanKeySalt != conf.CryptopanKeySalt ||
-			oldConf.CryptopanAddressEntries != conf.CryptopanAddressEntries {
+			oldConf.CryptopanKeySalt != conf.CryptopanKeySalt {
 			edm.log.Info("configUpdater: updating Crypto-PAn instance")
 			err = edm.setCryptopan(conf.CryptopanKey, conf.CryptopanKeySalt, conf.CryptopanAddressEntries)
 			if err != nil {
@@ -822,15 +821,7 @@ func (edm *dnstapMinimiser) setIgnoredQuestionNames() error {
 	conf := edm.getConfig()
 
 	if conf.IgnoredQuestionNamesFile == "" {
-		edm.ignoredQuestionsMutex.Lock()
-		if edm.ignoredQuestions != nil {
-			err := edm.ignoredQuestions.Close()
-			if err != nil {
-				edm.log.Error("setIgnoredQuestionNames: failed closing edm.ignoredQuestions for unset filename", "error", err)
-			}
-			edm.ignoredQuestions = nil
-		}
-		edm.ignoredQuestionsMutex.Unlock()
+		edm.ignoredQuestions.Store(nil)
 		edm.log.Info("setIgnoredQuestionNames: DNS question ignore list unset", "filename", conf.IgnoredQuestionNamesFile, "num_names", 0)
 		return nil
 	}
@@ -839,38 +830,23 @@ func (edm *dnstapMinimiser) setIgnoredQuestionNames() error {
 	if err != nil {
 		if errors.Is(err, errEmptyDawgFile) {
 			// Treat the same as unset filename
-			edm.ignoredQuestionsMutex.Lock()
-			if edm.ignoredQuestions != nil {
-				err := edm.ignoredQuestions.Close()
-				if err != nil {
-					edm.log.Error("setIgnoredQuestionNames: failed closing edm.ignoredQuestions for unset filename", "error", err)
-				}
-				edm.ignoredQuestions = nil
-			}
-			edm.ignoredQuestionsMutex.Unlock()
+			edm.ignoredQuestions.Store(nil)
 			edm.log.Info("setIgnoredQuestionNames: DNS question ignore list empty", "filename", conf.IgnoredQuestionNamesFile, "num_names", 0)
 			return nil
-
 		}
 		return fmt.Errorf("setIgnoredQuestionNames: unable to load dawg file '%s': %w", conf.IgnoredQuestionNamesFile, err)
 	}
 
-	// We only use the dawg file if there exists at least one name
-	// in it. Since the file can be empty we must also be prepared to set
-	// our edm field to nil so we do not keep using an old list.
-	edm.ignoredQuestionsMutex.Lock()
-	if edm.ignoredQuestions != nil {
-		err = edm.ignoredQuestions.Close()
-		if err != nil {
-			edm.log.Error("setIgnoredQuestionNames: failed closing edm.ignoredQuestions", "error", err)
-		}
-	}
+	// We only use the dawg file if there exists at least one name in it.
+	// Atomic-pointer swap; deliberately do NOT Close the old finder here
+	// as that would race with hot-path readers still holding it. Reloads
+	// leave the old finder for the GC to reclaim once no reader references
+	// it (see the ignoredQuestions field comment on dnstapMinimiser).
 	if dawgFinder.NumAdded() > 0 {
-		edm.ignoredQuestions = dawgFinder
+		edm.ignoredQuestions.Store(&dawgFinderHolder{finder: dawgFinder})
 	} else {
-		edm.ignoredQuestions = nil
+		edm.ignoredQuestions.Store(nil)
 	}
-	edm.ignoredQuestionsMutex.Unlock()
 
 	if dawgFinder.NumAdded() > 0 {
 		edm.log.Info("setIgnoredQuestionNames: DNS question ignore list loaded", "filename", conf.IgnoredQuestionNamesFile, "num_names", dawgFinder.NumAdded())
@@ -885,10 +861,8 @@ func (edm *dnstapMinimiser) setIgnoredClientIPs() error {
 	conf := edm.getConfig()
 
 	if conf.IgnoredClientIPsFile == "" {
-		edm.ignoredClientsIPSetMutex.Lock()
-		edm.ignoredClientsIPSet = nil
-		edm.ignoredClientCIDRsParsed = 0
-		edm.ignoredClientsIPSetMutex.Unlock()
+		edm.ignoredClientsIPSet.Store(nil)
+		edm.ignoredClientCIDRsParsed.Store(0)
 		edm.log.Info("setIgnoredClientIPs: DNS client ignore list unset", "filename", conf.IgnoredClientIPsFile, "num_cidrs", 0)
 		return nil
 	}
@@ -934,10 +908,8 @@ func (edm *dnstapMinimiser) setIgnoredClientIPs() error {
 		}
 	}
 
-	edm.ignoredClientsIPSetMutex.Lock()
-	edm.ignoredClientsIPSet = ipset
-	edm.ignoredClientCIDRsParsed = numCIDRs
-	edm.ignoredClientsIPSetMutex.Unlock()
+	edm.ignoredClientsIPSet.Store(ipset)
+	edm.ignoredClientCIDRsParsed.Store(numCIDRs)
 
 	if ipset != nil {
 		edm.log.Info("setIgnoredClientIPs: DNS client ignore list loaded", "filename", conf.IgnoredClientIPsFile, "num_cidrs", numCIDRs)
@@ -949,10 +921,7 @@ func (edm *dnstapMinimiser) setIgnoredClientIPs() error {
 }
 
 func (edm *dnstapMinimiser) getNumIgnoredClientCIDRs() uint64 {
-	edm.ignoredClientsIPSetMutex.RLock()
-	defer edm.ignoredClientsIPSetMutex.RUnlock()
-
-	return edm.ignoredClientCIDRsParsed
+	return edm.ignoredClientCIDRsParsed.Load()
 }
 
 func (edm *dnstapMinimiser) fsEventWatcher() {
@@ -1502,48 +1471,59 @@ func run(edm *dnstapMinimiser, logger *slog.Logger, loggerLevel *slog.LevelVar) 
 }
 
 type dnstapMinimiser struct {
-	configer                      edmConfiger
-	conf                          config
-	confMutex                     sync.RWMutex
-	inputChannel                  chan []byte          // the channel expected to be passed to dnstap ReadInto()
-	log                           *slog.Logger         // any information logging is sent here
-	cryptopan                     *cryptopan.Cryptopan // used for pseudonymising IP addresses
-	cryptopanCache                *lru.Cache[netip.Addr, netip.Addr]
-	cryptopanMutex                sync.RWMutex // Mutex for protecting updates cryptopan at runtime
-	promReg                       *prometheus.Registry
-	promCryptopanCacheHit         prometheus.Counter
-	promCryptopanCacheEvicted     prometheus.Counter
-	promDnstapProcessed           prometheus.Counter
-	promNewQnameQueued            prometheus.Counter
-	promNewQnameDiscarded         prometheus.Counter
-	promSeenQnameLRUEvicted       prometheus.Counter
-	promNewQnameChannelLen        prometheus.Gauge
-	promClientIPIgnored           prometheus.Counter
-	promClientIPIgnoredError      prometheus.Counter
-	promQuestionNameIgnored       prometheus.Counter
-	promDNSParseError             prometheus.Counter
-	promEmptyQuestionSection      prometheus.Counter
-	promInvalidQuestionName       prometheus.Counter
-	ctx                           context.Context
-	stop                          context.CancelFunc // call this to gracefully stop runMinimiser()
-	debug                         bool               // if we should print debug messages during operation
-	sessionWriterCh               chan *prevSessions
-	histogramWriterCh             chan *wellKnownDomainsData
-	parquetRotationRequestCh      chan parquetRotationRequest
-	newQnamePublisherCh           chan *protocols.NewQnameJSON
-	sessionCollectorCh            chan *sessionData
-	aggregSenderMutex             sync.RWMutex
-	aggregSender                  aggregateSender
-	mqttPubCh                     chan []byte
-	mqttSignedCh                  chan []byte
-	autopahoCtx                   context.Context
-	autopahoCancel                context.CancelFunc
-	autopahoWg                    sync.WaitGroup
-	ignoredClientsIPSet           *netipx.IPSet
-	ignoredClientCIDRsParsed      uint64
-	ignoredClientsIPSetMutex      sync.RWMutex // Mutex for protecting updates to ignored client IPs at runtime
-	ignoredQuestions              dawg.Finder
-	ignoredQuestionsMutex         sync.RWMutex
+	configer     edmConfiger
+	conf         config
+	confMutex    sync.RWMutex
+	inputChannel chan []byte  // the channel expected to be passed to dnstap ReadInto()
+	log          *slog.Logger // any information logging is sent here
+
+	// Cryptopan instance is held in an atomic.Pointer so the hot path
+	// reads it without locking. setCryptopan swaps the pointer and
+	// bumps cryptopanGen; per-worker caches compare their last-seen
+	// generation against this and Purge when it changes.
+	cryptopan                 atomic.Pointer[cryptopan.Cryptopan]
+	cryptopanGen              atomic.Uint64
+	promReg                   *prometheus.Registry
+	promCryptopanCacheHit     prometheus.Counter
+	promCryptopanCacheEvicted prometheus.Counter
+	promDnstapProcessed       prometheus.Counter
+	promNewQnameQueued        prometheus.Counter
+	promNewQnameDiscarded     prometheus.Counter
+	promSeenQnameLRUEvicted   prometheus.Counter
+	promNewQnameChannelLen    prometheus.Gauge
+	promClientIPIgnored       prometheus.Counter
+	promClientIPIgnoredError  prometheus.Counter
+	promQuestionNameIgnored   prometheus.Counter
+	promDNSParseError         prometheus.Counter
+	promEmptyQuestionSection  prometheus.Counter
+	promInvalidQuestionName   prometheus.Counter
+	ctx                       context.Context
+	stop                      context.CancelFunc // call this to gracefully stop runMinimiser()
+	debug                     bool               // if we should print debug messages during operation
+	sessionWriterCh           chan *prevSessions
+	histogramWriterCh         chan *wellKnownDomainsData
+	parquetRotationRequestCh  chan parquetRotationRequest
+	newQnamePublisherCh       chan *protocols.NewQnameJSON
+	sessionCollectorCh        chan *sessionData
+	aggregSenderMutex         sync.RWMutex
+	aggregSender              aggregateSender
+	mqttPubCh                 chan []byte
+	mqttSignedCh              chan []byte
+	autopahoCtx               context.Context
+	autopahoCancel            context.CancelFunc
+	autopahoWg                sync.WaitGroup
+	// Hot-path lookups (clientIPIsIgnored, questionIsIgnored) read these
+	// without locking. Reload writers atomic.Store a fresh value and leave the
+	// old value for the GC to reclaim. For ignoredQuestions the dawgFinderHolder
+	// wrapper is needed because dawg.Finder is an interface and atomic.Pointer
+	// wants a concrete type; its old finder is deliberately NOT Close()d on
+	// swap, since Close() (munmap) would race with hot-path readers still
+	// holding the old pointer. Reloads are rare and the mmap is small, so that
+	// bounded leak is acceptable. ignoredClientsIPSet is plain heap memory with
+	// no Close, reclaimed by the GC like any other dropped pointer.
+	ignoredClientsIPSet           atomic.Pointer[netipx.IPSet]
+	ignoredClientCIDRsParsed      atomic.Uint64
+	ignoredQuestions              atomic.Pointer[dawgFinderHolder]
 	fsWatcher                     *fsnotify.Watcher
 	fsWatcherFuncs                map[string][]func() error
 	fsWatcherMutex                sync.RWMutex
@@ -1706,38 +1686,60 @@ func newDnstapMinimiser(logger *slog.Logger, edmConf edmConfiger) (*dnstapMinimi
 	return edm, nil
 }
 
-type wellKnownDomainsTracker struct {
-	mutex sync.RWMutex
-	wellKnownDomainsData
-	updateCh    chan wkdUpdate
+// dawgFinderHolder is a tiny concrete-type wrapper so dawg.Finder (which is
+// an interface) can be stored in an atomic.Pointer. Used for the
+// ignoredQuestions atomic snapshot.
+type dawgFinderHolder struct {
+	finder dawg.Finder
+}
+
+// wkdSnapshot is the read-side view that hot-path callers need: the current
+// DAWG finder plus the modtime that goes into wkdUpdate so the collector can
+// detect post-rotation refresh. Stored in wellKnownDomainsTracker.snap as
+// an atomic.Pointer so lookup() reads it without locking.
+type wkdSnapshot struct {
+	dawgFinder  dawg.Finder
 	dawgModTime time.Time
+}
+
+type wellKnownDomainsTracker struct {
+	// snap holds the current DAWG + modtime. Replaced atomically when
+	// the dawg file rotates; readers in lookup() do a single Load.
+	snap atomic.Pointer[wkdSnapshot]
+
+	// m is the per-dawgIndex histogram aggregator. It is read & written
+	// only by dataCollector (the same goroutine that calls
+	// rotateTracker), so it needs no lock.
+	m map[int]*histogramData
+
+	updateCh    chan wkdUpdate
 	retryCh     chan wkdUpdate
 	stop        chan struct{}
 	retryerDone chan struct{}
 }
 
+// wellKnownDomainsData is a per-interval histogram batch handed to the
+// histogram writer. m is the interval's bucket map and dawgFinder is the DAWG
+// used to map bucket indices back to names. It is produced by rotateTracker
+// on normal rotation and by the shutdown flush in dataCollector; in both cases
+// dawgFinder is the snapshot finder that was active for the data in m.
 type wellKnownDomainsData struct {
-	// Store a pointer to histogramData so we can assign to it without
-	// "cannot assign to struct field in map" issues
-	m             map[int]*histogramData
-	startTime     time.Time
-	rotationTime  time.Time
-	dawgFinder    dawg.Finder
-	dawgIsRotated bool
+	m            map[int]*histogramData
+	startTime    time.Time
+	rotationTime time.Time
+	dawgFinder   dawg.Finder
 }
 
 func newWellKnownDomainsTracker(dawgFinder dawg.Finder, dawgModTime time.Time) (*wellKnownDomainsTracker, error) {
-	return &wellKnownDomainsTracker{
-		wellKnownDomainsData: wellKnownDomainsData{
-			m:          map[int]*histogramData{},
-			dawgFinder: dawgFinder,
-		},
+	wkd := &wellKnownDomainsTracker{
+		m:           map[int]*histogramData{},
 		updateCh:    make(chan wkdUpdate, 10000),
 		retryCh:     make(chan wkdUpdate, 10000),
-		dawgModTime: dawgModTime,
 		stop:        make(chan struct{}),
 		retryerDone: make(chan struct{}),
-	}, nil
+	}
+	wkd.snap.Store(&wkdSnapshot{dawgFinder: dawgFinder, dawgModTime: dawgModTime})
+	return wkd, nil
 }
 
 // Try to find a domain name string match in DAWG data and return the index as
@@ -1779,12 +1781,9 @@ type wkdUpdate struct {
 }
 
 func (wkd *wellKnownDomainsTracker) lookup(msg *dns.Msg) (int, bool, time.Time) {
-	wkd.mutex.RLock()
-	defer wkd.mutex.RUnlock()
-
-	dawgIndex, suffixMatch := getDawgIndex(wkd.dawgFinder, msg.Question[0].Name)
-
-	return dawgIndex, suffixMatch, wkd.dawgModTime
+	snap := wkd.snap.Load()
+	dawgIndex, suffixMatch := getDawgIndex(snap.dawgFinder, msg.Question[0].Name)
+	return dawgIndex, suffixMatch, snap.dawgModTime
 }
 
 func (wkd *wellKnownDomainsTracker) updateRetryer(edm *dnstapMinimiser, wg *sync.WaitGroup) {
@@ -1799,7 +1798,7 @@ func (wkd *wellKnownDomainsTracker) updateRetryer(edm *dnstapMinimiser, wg *sync
 
 		dawgIndex, suffixMatch, dawgModTime := wkd.lookup(wu.msg)
 		if dawgIndex == dawgNotFound {
-			edm.log.Info("ignoring wkd update because name does not exist in updated wkd tracker", "update_dawg_modtime", wkd.dawgModTime, "wkd_dawg_modtime", wkd.dawgModTime)
+			edm.log.Info("ignoring wkd update because name does not exist in updated wkd tracker", "update_dawg_modtime", wu.dawgModTime, "wkd_dawg_modtime", dawgModTime)
 			continue
 		}
 
@@ -1880,30 +1879,33 @@ func (wkd *wellKnownDomainsTracker) rotateTracker(edm *dnstapMinimiser, dawgFile
 		return nil, fmt.Errorf("rotateTracker: unable to stat dawgFile '%s': %w", dawgFile, err)
 	}
 
-	if fileInfo.ModTime() != wkd.dawgModTime {
+	curSnap := wkd.snap.Load()
+	if fileInfo.ModTime() != curSnap.dawgModTime {
 		dawgFinder, dawgModTime, err = loadDawgFile(dawgFile)
 		if err != nil {
 			return nil, fmt.Errorf("rotateTracker: loadDawgFile(): %w", err)
 		}
 		dawgFileChanged = true
-		edm.log.Info("dawg file modification changed, will reload file", "prev_time", wkd.dawgModTime, "cur_time", fileInfo.ModTime())
+		edm.log.Info("dawg file modification changed, will reload file", "prev_time", curSnap.dawgModTime, "cur_time", fileInfo.ModTime())
 	}
 
-	prevWKD := &wellKnownDomainsData{}
-
-	// Swap the map in use so we can write parquet data outside of the write lock
-	wkd.mutex.Lock()
-	prevWKD.m = wkd.m
-	prevWKD.dawgFinder = wkd.dawgFinder
-	prevWKD.startTime = startTime
-	prevWKD.rotationTime = rotationTime
+	// rotateTracker runs in the dataCollector goroutine, which is also
+	// the only writer of wkd.m (see the case wu := <-wkd.updateCh branch).
+	// No lock needed for the map swap. The DAWG snapshot is a separate
+	// atomic Store so hot-path lookup() callers see a consistent view.
+	prevWKD := &wellKnownDomainsData{
+		m:            wkd.m,
+		dawgFinder:   curSnap.dawgFinder,
+		startTime:    startTime,
+		rotationTime: rotationTime,
+	}
 	wkd.m = map[int]*histogramData{}
 	if dawgFileChanged {
-		wkd.dawgFinder = dawgFinder
-		wkd.dawgModTime = dawgModTime
-		prevWKD.dawgIsRotated = true
+		wkd.snap.Store(&wkdSnapshot{
+			dawgFinder:  dawgFinder,
+			dawgModTime: dawgModTime,
+		})
 	}
-	wkd.mutex.Unlock()
 
 	return prevWKD, nil
 }
@@ -1956,49 +1958,44 @@ func (edm *dnstapMinimiser) qnameSeen(msg *dns.Msg, seenQnameLRU *lru.Cache[stri
 }
 
 func (edm *dnstapMinimiser) clientIPIsIgnored(dt *dnstap.Dnstap) bool {
-	// edm.ignoredClientsIPSet can be modified at runtime so wrap everything
-	// in a RO lock
-	edm.ignoredClientsIPSetMutex.RLock()
-	defer edm.ignoredClientsIPSetMutex.RUnlock()
-
-	if edm.ignoredClientsIPSet != nil {
-		clientIP, ok := netip.AddrFromSlice(dt.Message.QueryAddress)
-		if !ok {
-			// If we have a list of clients to
-			// ignore but are not able to
-			// understand the QueryAddress lets err
-			// on the side of caution and ignore
-			// such packets as well while making
-			// noise in logs so it can be investigated
-			edm.log.Error("unable to parse QueryAddress for ignore-checking, ignoring dnstap packet to be safe, please investigate")
-			edm.promClientIPIgnoredError.Inc()
-			return true
-		}
-
-		if edm.ignoredClientsIPSet.Contains(clientIP) {
-			edm.promClientIPIgnored.Inc()
-			return true
-		}
+	// Atomic snapshot - no lock on the hot path. Reload writers
+	// atomic.Store the new IPSet; readers see either old or new value
+	// per Load.
+	ipset := edm.ignoredClientsIPSet.Load()
+	if ipset == nil {
+		return false
+	}
+	clientIP, ok := netip.AddrFromSlice(dt.Message.QueryAddress)
+	if !ok {
+		// If we have a list of clients to ignore but are not able to
+		// understand the QueryAddress let's err on the side of caution
+		// and ignore such packets as well while making noise in logs
+		// so it can be investigated.
+		edm.log.Error("unable to parse QueryAddress for ignore-checking, ignoring dnstap packet to be safe, please investigate")
+		edm.promClientIPIgnoredError.Inc()
+		return true
+	}
+	if ipset.Contains(clientIP) {
+		edm.promClientIPIgnored.Inc()
+		return true
 	}
 	return false
 }
 
 func (edm *dnstapMinimiser) questionIsIgnored(msg *dns.Msg) bool {
-	// edm.ignoredQuestions can be modified at runtime so wrap everything
-	// in a RO lock
-	edm.ignoredQuestionsMutex.RLock()
-	defer edm.ignoredQuestionsMutex.RUnlock()
-
-	if edm.ignoredQuestions != nil {
-		// While uncommon, if there happens to be multiple questions in
-		// the packet we will consider the message ignored if any of them matches the
-		// ignore list.
-		for _, question := range msg.Question {
-			dawgIndex, _ := getDawgIndex(edm.ignoredQuestions, question.Name)
-			if dawgIndex != dawgNotFound {
-				edm.promQuestionNameIgnored.Inc()
-				return true
-			}
+	// Atomic snapshot - no lock on the hot path. See clientIPIsIgnored
+	// for the rationale.
+	holder := edm.ignoredQuestions.Load()
+	if holder == nil {
+		return false
+	}
+	// While uncommon, if there happens to be multiple questions in the
+	// packet we consider the message ignored if any of them matches.
+	for _, question := range msg.Question {
+		dawgIndex, _ := getDawgIndex(holder.finder, question.Name)
+		if dawgIndex != dawgNotFound {
+			edm.promQuestionNameIgnored.Inc()
+			return true
 		}
 	}
 	return false
@@ -2019,6 +2016,23 @@ func (edm *dnstapMinimiser) runMinimiser(minimiserID int, wg *sync.WaitGroup, se
 
 	// startConf is used for things that do not handle reconfiguration at runtime
 	startConf := edm.getConfig()
+
+	// Per-worker Crypto-PAn cache. Each worker holds its own LRU so the
+	// pseudonymise hot path takes no shared lock. cryptopanLastGen tracks
+	// the last cryptopan-instance generation we saw; when setCryptopan
+	// installs a new key it bumps edm.cryptopanGen and we Purge on the next
+	// frame, so at most one frame after a key rotation can still return a
+	// cached old-key pseudonym before the cache is cleared.
+	var cryptopanCache *lru.Cache[netip.Addr, netip.Addr]
+	if startConf.CryptopanAddressEntries != 0 {
+		var lerr error
+		cryptopanCache, lerr = lru.New[netip.Addr, netip.Addr](startConf.CryptopanAddressEntries)
+		if lerr != nil {
+			edm.log.Error("runMinimiser: unable to create per-worker cryptopan cache", "error", lerr, "minimiser_id", minimiserID)
+			return
+		}
+	}
+	cryptopanLastGen := edm.cryptopanGen.Load()
 
 	// conf is meant to be dynamically modified if the config changes at runtime
 	conf := edm.getConfig()
@@ -2082,7 +2096,15 @@ minimiserLoop:
 			}
 			copy(dangerRealClientIP, dt.Message.QueryAddress)
 
-			edm.pseudonymiseDnstap(dt)
+			// Detect cryptopan key rotation; purge our local cache so
+			// no IPs anonymised under the old key bleed through.
+			if gen := edm.cryptopanGen.Load(); gen != cryptopanLastGen {
+				if cryptopanCache != nil {
+					cryptopanCache.Purge()
+				}
+				cryptopanLastGen = gen
+			}
+			edm.pseudonymiseDnstap(dt, edm.cryptopan.Load(), cryptopanCache)
 
 			msg, timestamp := edm.parsePacket(dt, isQuery)
 
@@ -2845,16 +2867,12 @@ func parseHllStorageType(hllBytes []byte) (hllStorageType, error) {
 }
 
 func (edm *dnstapMinimiser) writeHistogramParquet(output io.Writer, startTime time.Time, prevWellKnownDomainsData *wellKnownDomainsData, labelLimit int) error {
-	if prevWellKnownDomainsData.dawgIsRotated {
-		defer func() {
-			err := prevWellKnownDomainsData.dawgFinder.Close()
-			if err != nil {
-				edm.log.Error("writeHistogramParquet: unable to close dawgFinder", "error", err)
-			} else {
-				edm.log.Info("closed rotated dawgFinder instance")
-			}
-		}()
-	}
+	// The previous DAWG finder is intentionally NOT closed here. lookup() reads
+	// the well-known-domains finder lock-free via wkd.snap, so a minimiser
+	// worker may still hold a rotated-out finder; closing (munmapping) it would
+	// race with that reader and risk a use-after-free. The old finder is left
+	// for the GC to reclaim once no reader references it, matching the
+	// ignoredQuestions/ignoredClients atomic-reload policy.
 
 	snappyCodec := parquet.LookupCompressionCodec(format.Snappy)
 	parquetWriter := parquet.NewGenericWriter[histogramData](output, parquet.Compression(snappyCodec))
@@ -2946,30 +2964,31 @@ func certPoolFromFile(fileName string) (*x509.CertPool, error) {
 	return certPool, nil
 }
 
-// Pseudonymise IP address fields in a dnstap message
-func (edm *dnstapMinimiser) pseudonymiseDnstap(dt *dnstap.Dnstap) {
+// pseudonymiseDnstap pseudonymises the IP address fields in a dnstap message.
+//
+// cache is the caller's per-worker LRU; cpn is a snapshot of the current
+// cryptopan instance taken once per frame so QueryAddress and ResponseAddress
+// see the same key. The per-worker cache and cryptopan snapshot are passed in
+// rather than read from shared state, so the hot path needs no locking.
+func (edm *dnstapMinimiser) pseudonymiseDnstap(dt *dnstap.Dnstap, cpn *cryptopan.Cryptopan, cache *lru.Cache[netip.Addr, netip.Addr]) {
 	var err error
-
-	// Lock is used here because the cryptopan instance can get updated at runtime.
-	edm.cryptopanMutex.RLock()
-
 	if dt.Message.QueryAddress != nil {
-		dt.Message.QueryAddress, err = edm.pseudonymiseIP(dt.Message.QueryAddress)
+		dt.Message.QueryAddress, err = edm.pseudonymiseIP(dt.Message.QueryAddress, cpn, cache)
 		if err != nil {
 			edm.log.Error("pseudonymiseDnstap: unable to parse dt.Message.QueryAddress", "error", err)
 		}
 	}
 	if dt.Message.ResponseAddress != nil {
-		dt.Message.ResponseAddress, err = edm.pseudonymiseIP(dt.Message.ResponseAddress)
+		dt.Message.ResponseAddress, err = edm.pseudonymiseIP(dt.Message.ResponseAddress, cpn, cache)
 		if err != nil {
 			edm.log.Error("pseudonymiseDnstap: unable to parse dt.Message.ResponseAddress", "error", err)
 		}
 	}
-	edm.cryptopanMutex.RUnlock()
 }
 
-// Pseudonymise IP address, even on error the returned []byte is usable (zeroed address)
-func (edm *dnstapMinimiser) pseudonymiseIP(ipBytes []byte) ([]byte, error) {
+// Pseudonymise IP address, even on error the returned []byte is usable (zeroed address).
+// Caller passes the per-worker cache and the cryptopan snapshot; nil cache disables caching.
+func (edm *dnstapMinimiser) pseudonymiseIP(ipBytes []byte, cpn *cryptopan.Cryptopan, cache *lru.Cache[netip.Addr, netip.Addr]) ([]byte, error) {
 	addr, ok := netip.AddrFromSlice(ipBytes)
 	if !ok {
 		// Replace address with zeroes since we do not know if
@@ -2980,15 +2999,15 @@ func (edm *dnstapMinimiser) pseudonymiseIP(ipBytes []byte) ([]byte, error) {
 	var pseudonymisedAddr netip.Addr
 	var cacheHit bool
 
-	if edm.cryptopanCache != nil {
-		pseudonymisedAddr, cacheHit = edm.cryptopanCache.Get(addr)
+	if cache != nil {
+		pseudonymisedAddr, cacheHit = cache.Get(addr)
 	}
 
 	if cacheHit {
 		edm.promCryptopanCacheHit.Inc()
 	} else {
 		// Not in cache or cache disabled, calculate the pseudonymised IP
-		pseudonymisedAddr, ok = netip.AddrFromSlice(edm.cryptopan.Anonymize(addr.AsSlice()))
+		pseudonymisedAddr, ok = netip.AddrFromSlice(cpn.Anonymize(addr.AsSlice()))
 		if !ok {
 			// Replace address with zeroes here as well
 			// since we do not know if the contained junk
@@ -3002,8 +3021,8 @@ func (edm *dnstapMinimiser) pseudonymiseIP(ipBytes []byte) ([]byte, error) {
 		// IPv4 addresses in our system so call Unmap() on it.
 		pseudonymisedAddr = pseudonymisedAddr.Unmap()
 
-		if edm.cryptopanCache != nil {
-			evicted := edm.cryptopanCache.Add(addr, pseudonymisedAddr)
+		if cache != nil {
+			evicted := cache.Add(addr, pseudonymisedAddr)
 			if evicted {
 				edm.promCryptopanCacheEvicted.Inc()
 			}
@@ -3108,7 +3127,7 @@ func (edm *dnstapMinimiser) dataCollector(wg *sync.WaitGroup, wkd *wellKnownDoma
 		// to do a new lookup against the new dawg to make sure
 		// we have the correct index number (or if it is even
 		// present in the new dawg).
-		if wu.dawgModTime != wkd.dawgModTime {
+		if wu.dawgModTime != wkd.snap.Load().dawgModTime {
 			if !retryChannelClosed {
 				wkd.retryCh <- wu
 			} else {
@@ -3178,7 +3197,7 @@ func (edm *dnstapMinimiser) dataCollector(wg *sync.WaitGroup, wkd *wellKnownDoma
 			m:            wkd.m,
 			startTime:    startTime,
 			rotationTime: rotationTime,
-			dawgFinder:   wkd.dawgFinder,
+			dawgFinder:   wkd.snap.Load().dawgFinder,
 		}
 		wkd.m = map[int]*histogramData{}
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -259,6 +259,7 @@ type sessionData struct {
 
 type prevSessions struct {
 	sessions     []*sessionData
+	startTime    time.Time
 	rotationTime time.Time
 }
 
@@ -1719,6 +1720,7 @@ type wellKnownDomainsData struct {
 	// Store a pointer to histogramData so we can assign to it without
 	// "cannot assign to struct field in map" issues
 	m             map[int]*histogramData
+	startTime     time.Time
 	rotationTime  time.Time
 	dawgFinder    dawg.Finder
 	dawgIsRotated bool
@@ -1868,7 +1870,7 @@ func (wkd *wellKnownDomainsTracker) sendUpdate(ipBytes []byte, msg *dns.Msg, daw
 	wkd.updateCh <- wu
 }
 
-func (wkd *wellKnownDomainsTracker) rotateTracker(edm *dnstapMinimiser, dawgFile string, rotationTime time.Time) (*wellKnownDomainsData, error) {
+func (wkd *wellKnownDomainsTracker) rotateTracker(edm *dnstapMinimiser, dawgFile string, startTime time.Time, rotationTime time.Time) (*wellKnownDomainsData, error) {
 	dawgFileChanged := false
 	var dawgFinder dawg.Finder
 	var dawgModTime time.Time
@@ -1893,6 +1895,8 @@ func (wkd *wellKnownDomainsTracker) rotateTracker(edm *dnstapMinimiser, dawgFile
 	wkd.mutex.Lock()
 	prevWKD.m = wkd.m
 	prevWKD.dawgFinder = wkd.dawgFinder
+	prevWKD.startTime = startTime
+	prevWKD.rotationTime = rotationTime
 	wkd.m = map[int]*histogramData{}
 	if dawgFileChanged {
 		wkd.dawgFinder = dawgFinder
@@ -1900,8 +1904,6 @@ func (wkd *wellKnownDomainsTracker) rotateTracker(edm *dnstapMinimiser, dawgFile
 		prevWKD.dawgIsRotated = true
 	}
 	wkd.mutex.Unlock()
-
-	prevWKD.rotationTime = rotationTime
 
 	return prevWKD, nil
 }
@@ -2284,7 +2286,7 @@ func (edm *dnstapMinimiser) createSessionFile(ps *prevSessions, dataDir string) 
 	// Write session file to a sessions dir where it can be read by other tools
 	sessionsDir := filepath.Join(dataDir, "parquet", "sessions")
 
-	startTime := getStartTimeFromRotationTime(ps.rotationTime)
+	startTime := intervalStartFromTimes(ps.startTime, ps.rotationTime)
 
 	absoluteTmpFileName, absoluteFileName := buildParquetFilenames(sessionsDir, "dns_session_block", startTime, ps.rotationTime)
 
@@ -2315,7 +2317,7 @@ func (edm *dnstapMinimiser) sessionWriter(dataDir string, wg *sync.WaitGroup) {
 }
 
 func (edm *dnstapMinimiser) createHistogramFile(prevWellKnownDomainsData *wellKnownDomainsData, labelLimit int, outboxDir string) (string, error) {
-	startTime := getStartTimeFromRotationTime(prevWellKnownDomainsData.rotationTime)
+	startTime := intervalStartFromTimes(prevWellKnownDomainsData.startTime, prevWellKnownDomainsData.rotationTime)
 
 	absoluteTmpFileName, absoluteFileName := buildParquetFilenames(outboxDir, "dns_histogram", startTime, prevWellKnownDomainsData.rotationTime)
 
@@ -2789,6 +2791,13 @@ func getStartTimeFromRotationTime(rotationTime time.Time) time.Time {
 	return rotationTime.Add(-time.Second * 60)
 }
 
+func intervalStartFromTimes(startTime time.Time, rotationTime time.Time) time.Time {
+	if !startTime.IsZero() {
+		return startTime
+	}
+	return getStartTimeFromRotationTime(rotationTime)
+}
+
 // Unfortunately the hll library does not expose what format
 // the HLL is being stored in so figure things out manually.
 //
@@ -3058,6 +3067,8 @@ func (edm *dnstapMinimiser) dataCollector(wg *sync.WaitGroup, wkd *wellKnownDoma
 	go wkd.updateRetryer(edm, &retryerWg)
 
 	sessions := []*sessionData{}
+	sessionIntervalStart := time.Now().UTC()
+	histogramIntervalStart := sessionIntervalStart
 
 	ticker := time.NewTicker(timeUntilNextMinute())
 	defer ticker.Stop()
@@ -3076,12 +3087,13 @@ func (edm *dnstapMinimiser) dataCollector(wg *sync.WaitGroup, wkd *wellKnownDoma
 		sessionUpdated = true
 	}
 
-	flushSessions := func(rotationTime time.Time) {
+	flushSessions := func(startTime time.Time, rotationTime time.Time) {
 		if !sessionUpdated {
 			return
 		}
 		ps := &prevSessions{
 			sessions:     sessions,
+			startTime:    startTime,
 			rotationTime: rotationTime,
 		}
 		sessions = []*sessionData{}
@@ -3142,10 +3154,10 @@ func (edm *dnstapMinimiser) dataCollector(wg *sync.WaitGroup, wkd *wellKnownDoma
 		}
 	}
 
-	rotateCollectedData := func(rotationTime time.Time) error {
-		flushSessions(rotationTime)
+	rotateCollectedData := func(sessionStart time.Time, histogramStart time.Time, rotationTime time.Time) error {
+		flushSessions(sessionStart, rotationTime)
 
-		prevWKD, err := wkd.rotateTracker(edm, dawgFile, rotationTime)
+		prevWKD, err := wkd.rotateTracker(edm, dawgFile, histogramStart, rotationTime)
 		if err != nil {
 			return fmt.Errorf("unable to rotate histogram map: %w", err)
 		}
@@ -3156,6 +3168,19 @@ func (edm *dnstapMinimiser) dataCollector(wg *sync.WaitGroup, wkd *wellKnownDoma
 		}
 
 		return nil
+	}
+
+	flushHistogram := func(startTime time.Time, rotationTime time.Time) {
+		if len(wkd.m) == 0 {
+			return
+		}
+		edm.histogramWriterCh <- &wellKnownDomainsData{
+			m:            wkd.m,
+			startTime:    startTime,
+			rotationTime: rotationTime,
+			dawgFinder:   wkd.dawgFinder,
+		}
+		wkd.m = map[int]*histogramData{}
 	}
 
 collectorLoop:
@@ -3171,10 +3196,14 @@ collectorLoop:
 			// We want to tick at the start of each minute
 			ticker.Reset(timeUntilNextMinute())
 
-			if err := rotateCollectedData(ts); err != nil {
+			err := rotateCollectedData(sessionIntervalStart, histogramIntervalStart, ts)
+			// Sessions were already flushed; advance their boundary regardless.
+			sessionIntervalStart = ts
+			if err != nil {
 				edm.log.Error("unable to rotate parquet data", "error", err)
 				continue
 			}
+			histogramIntervalStart = ts
 
 			// See if we need to modify anything based on a config update
 			conf = edm.getConfig()
@@ -3187,11 +3216,17 @@ collectorLoop:
 		case req := <-edm.parquetRotationRequestCh:
 			edm.log.Info("dataCollector: manual parquet rotation requested", "rotation_time", req.rotationTime)
 			drainCollectorQueues()
-			err := rotateCollectedData(req.rotationTime)
+			err := rotateCollectedData(sessionIntervalStart, histogramIntervalStart, req.rotationTime)
+			// Sessions were already flushed; advance their boundary regardless.
+			sessionIntervalStart = req.rotationTime
 			req.done <- err
 			if err != nil {
 				edm.log.Error("unable to rotate parquet data", "error", err)
+				continue
 			}
+			// The histogram only rotates on success, so its boundary
+			// advances only once rotateTracker has succeeded.
+			histogramIntervalStart = req.rotationTime
 
 		case <-wkd.stop:
 			// Tell retryer to stop
@@ -3202,8 +3237,13 @@ collectorLoop:
 			// read from it again in this select statement now that
 			// it is closed.
 			wkd.stop = nil
+
 		case <-wkd.retryerDone:
 			edm.log.Info("dataCollector: update retryer is done")
+			drainCollectorQueues()
+			shutdownTime := time.Now().UTC()
+			flushSessions(sessionIntervalStart, shutdownTime)
+			flushHistogram(histogramIntervalStart, shutdownTime)
 			break collectorLoop
 		}
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -2589,21 +2589,30 @@ timerLoop:
 	edm.log.Info("histogramSender: exiting loop")
 }
 
-func timestampsFromFilename(name string) (time.Time, time.Time, error) {
+func timestampsFromFilename(name string) (startTime time.Time, stopTime time.Time, err error) {
 	// expected name format: dns_histogram-2023-11-29T13-50-00Z_2023-11-29T13-51-00Z.parquet
 	trimmedName := strings.TrimSuffix(name, ".parquet")
 	nameParts := strings.SplitN(trimmedName, "-", 2)
+	if len(nameParts) != 2 {
+		err = fmt.Errorf("timestampFromFilename: missing '-' separating prefix from timestamps in %q", name)
+		return
+	}
 	times := strings.Split(nameParts[1], "_")
-	startTime, err := time.Parse("2006-01-02T15-04-05Z07:00", times[0])
-	if err != nil {
-		return time.Time{}, time.Time{}, fmt.Errorf("timestampFromFilename: unable to parse startTime: %w", err)
+	if len(times) != 2 {
+		err = fmt.Errorf("timestampFromFilename: missing '_' separating start and stop timestamps in %q", name)
+		return
 	}
-	stopTime, err := time.Parse("2006-01-02T15-04-05Z07:00", times[1])
+	startTime, err = time.Parse("2006-01-02T15-04-05Z07:00", times[0])
 	if err != nil {
-		return time.Time{}, time.Time{}, fmt.Errorf("timestampFromFilename: unable to parse stopTime: %w", err)
+		err = fmt.Errorf("timestampFromFilename: unable to parse startTime: %w", err)
+		return
 	}
-
-	return startTime, stopTime, nil
+	stopTime, err = time.Parse("2006-01-02T15-04-05Z07:00", times[1])
+	if err != nil {
+		err = fmt.Errorf("timestampFromFilename: unable to parse stopTime: %w", err)
+		return
+	}
+	return
 }
 
 func (edm *dnstapMinimiser) newQnamePublisher(wg *sync.WaitGroup) {

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -935,15 +935,15 @@ func TestWellKnownDomainUpdatesAndRotation(t *testing.T) {
 		t.Fatal("timed out waiting for update")
 	}
 
-	prev, err := wkd.rotateTracker(edm, path, time.Unix(60, 0))
+	prev, err := wkd.rotateTracker(edm, path, time.Unix(0, 0), time.Unix(60, 0))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !prev.rotationTime.Equal(time.Unix(60, 0)) || len(wkd.m) != 0 {
+	if !prev.startTime.Equal(time.Unix(0, 0)) || !prev.rotationTime.Equal(time.Unix(60, 0)) || len(wkd.m) != 0 {
 		t.Fatalf("unexpected rotation state: %#v", prev)
 	}
 
-	if _, err := wkd.rotateTracker(edm, filepath.Join(t.TempDir(), "missing.dawg"), time.Now()); err == nil {
+	if _, err := wkd.rotateTracker(edm, filepath.Join(t.TempDir(), "missing.dawg"), time.Unix(0, 0), time.Now()); err == nil {
 		t.Fatal("rotateTracker with missing file succeeded")
 	}
 }

--- a/pkg/runner/runner_extra_test.go
+++ b/pkg/runner/runner_extra_test.go
@@ -391,12 +391,9 @@ func TestSetIgnoredQuestionNamesBranches(t *testing.T) {
 		if err := edm.setIgnoredQuestionNames(); err != nil {
 			t.Fatalf("initial load: %v", err)
 		}
-		edm.ignoredQuestionsMutex.RLock()
-		if edm.ignoredQuestions == nil {
-			edm.ignoredQuestionsMutex.RUnlock()
+		if edm.ignoredQuestions.Load() == nil {
 			t.Fatal("expected finder loaded; got nil")
 		}
-		edm.ignoredQuestionsMutex.RUnlock()
 
 		// Unset the filename and reload — the close-on-replace branch
 		// fires and ignoredQuestions returns to nil.
@@ -404,9 +401,7 @@ func TestSetIgnoredQuestionNamesBranches(t *testing.T) {
 		if err := edm.setIgnoredQuestionNames(); err != nil {
 			t.Fatalf("unset reload: %v", err)
 		}
-		edm.ignoredQuestionsMutex.RLock()
-		defer edm.ignoredQuestionsMutex.RUnlock()
-		if edm.ignoredQuestions != nil {
+		if edm.ignoredQuestions.Load() != nil {
 			t.Fatal("expected finder cleared after unset; got non-nil")
 		}
 	})
@@ -427,9 +422,7 @@ func TestSetIgnoredQuestionNamesBranches(t *testing.T) {
 		if err := edm.setIgnoredQuestionNames(); err != nil {
 			t.Fatalf("empty file: %v", err)
 		}
-		edm.ignoredQuestionsMutex.RLock()
-		defer edm.ignoredQuestionsMutex.RUnlock()
-		if edm.ignoredQuestions != nil {
+		if edm.ignoredQuestions.Load() != nil {
 			t.Fatal("expected finder cleared for empty file; got non-nil")
 		}
 	})
@@ -443,9 +436,7 @@ func TestSetIgnoredQuestionNamesBranches(t *testing.T) {
 		if err := edm.setIgnoredQuestionNames(); err != nil {
 			t.Fatalf("zero-name dawg: %v", err)
 		}
-		edm.ignoredQuestionsMutex.RLock()
-		defer edm.ignoredQuestionsMutex.RUnlock()
-		if edm.ignoredQuestions != nil {
+		if edm.ignoredQuestions.Load() != nil {
 			t.Fatal("expected nil finder for zero-name dawg; got non-nil")
 		}
 	})
@@ -455,20 +446,27 @@ func TestSetIgnoredQuestionNamesBranches(t *testing.T) {
 // branches that TestIPConversionErrorsAndPseudonymiseInvalid (bad-slice)
 // and TestPseudonymiseDnstap (one-shot success) do not reach: cache hit,
 // cache eviction at the LRU size limit, and the cache-disabled path
-// reached via cryptopanCache == nil.
+// reached via a nil cache. pseudonymiseIP takes the per-worker cache and
+// the cryptopan snapshot as parameters, so each subtest manages its own
+// cache the way runMinimiser does.
 func TestPseudonymiseIPCacheBranches(t *testing.T) {
 	addrA := netip.MustParseAddr("198.51.100.20").AsSlice()
 	addrB := netip.MustParseAddr("198.51.100.30").AsSlice()
 
 	t.Run("cache hit on repeat", func(t *testing.T) {
 		edm := newTestDnstapMinimiser(t, defaultTC)
+		cpn := edm.cryptopan.Load()
+		cache, err := lru.New[netip.Addr, netip.Addr](10)
+		if err != nil {
+			t.Fatalf("lru.New: %v", err)
+		}
 		// First call populates the cache, second returns the cached
-		// value via cryptopanCache.Get — exercising the cacheHit arm.
-		first, err := edm.pseudonymiseIP(addrA)
+		// value via cache.Get — exercising the cacheHit arm.
+		first, err := edm.pseudonymiseIP(addrA, cpn, cache)
 		if err != nil {
 			t.Fatalf("first: %v", err)
 		}
-		second, err := edm.pseudonymiseIP(addrA)
+		second, err := edm.pseudonymiseIP(addrA, cpn, cache)
 		if err != nil {
 			t.Fatalf("second: %v", err)
 		}
@@ -479,47 +477,41 @@ func TestPseudonymiseIPCacheBranches(t *testing.T) {
 		// if caching were silently bypassed. Pin the assertion to the
 		// observable side-effect of the hit arm: exactly one entry in
 		// the LRU, keyed by addrA.
-		if edm.cryptopanCache == nil {
-			t.Fatal("cryptopanCache is nil")
-		}
-		if got := edm.cryptopanCache.Len(); got != 1 {
+		if got := cache.Len(); got != 1 {
 			t.Fatalf("cache len = %d, want 1", got)
 		}
-		if !edm.cryptopanCache.Contains(netip.MustParseAddr("198.51.100.20")) {
+		if !cache.Contains(netip.MustParseAddr("198.51.100.20")) {
 			t.Fatal("cache does not contain addrA")
 		}
 	})
 
 	t.Run("cache eviction at size limit", func(t *testing.T) {
 		edm := newTestDnstapMinimiser(t, defaultTC)
+		cpn := edm.cryptopan.Load()
 		// Shrink the LRU to a single entry so the second distinct
 		// address evicts the first — exercising the evicted arm and
 		// the promCryptopanCacheEvicted.Inc() call.
-		if err := edm.setCryptopan("key1", "aabbccddeeffgghh", 1); err != nil {
-			t.Fatalf("setCryptopan size 1: %v", err)
+		cache, err := lru.New[netip.Addr, netip.Addr](1)
+		if err != nil {
+			t.Fatalf("lru.New: %v", err)
 		}
-		if _, err := edm.pseudonymiseIP(addrA); err != nil {
+		if _, err := edm.pseudonymiseIP(addrA, cpn, cache); err != nil {
 			t.Fatalf("populate: %v", err)
 		}
-		if _, err := edm.pseudonymiseIP(addrB); err != nil {
+		if _, err := edm.pseudonymiseIP(addrB, cpn, cache); err != nil {
 			t.Fatalf("evict: %v", err)
 		}
-		if edm.cryptopanCache.Len() != 1 {
-			t.Fatalf("cache len = %d, want 1 after eviction", edm.cryptopanCache.Len())
+		if cache.Len() != 1 {
+			t.Fatalf("cache len = %d, want 1 after eviction", cache.Len())
 		}
 	})
 
 	t.Run("cache disabled bypasses cache logic", func(t *testing.T) {
 		edm := newTestDnstapMinimiser(t, defaultTC)
-		// cacheEntries=0 leaves cryptopanCache nil so the cache-Get
-		// and cache-Add branches are skipped entirely.
-		if err := edm.setCryptopan("key1", "aabbccddeeffgghh", 0); err != nil {
-			t.Fatalf("setCryptopan disabled: %v", err)
-		}
-		if edm.cryptopanCache != nil {
-			t.Fatal("cryptopanCache should be nil with cacheEntries=0")
-		}
-		if _, err := edm.pseudonymiseIP(addrA); err != nil {
+		cpn := edm.cryptopan.Load()
+		// A nil cache skips the cache-Get and cache-Add branches
+		// entirely, mirroring CryptopanAddressEntries == 0.
+		if _, err := edm.pseudonymiseIP(addrA, cpn, nil); err != nil {
 			t.Fatalf("pseudonymiseIP with disabled cache: %v", err)
 		}
 	})
@@ -583,7 +575,7 @@ func TestIPConversionErrorsAndPseudonymiseInvalid(t *testing.T) {
 	}
 
 	edm := newTestDnstapMinimiser(t, defaultTC)
-	got, err := edm.pseudonymiseIP([]byte{1, 2, 3})
+	got, err := edm.pseudonymiseIP([]byte{1, 2, 3}, edm.cryptopan.Load(), nil)
 	if err == nil {
 		t.Fatal("invalid pseudonymiseIP succeeded")
 	}
@@ -592,7 +584,7 @@ func TestIPConversionErrorsAndPseudonymiseInvalid(t *testing.T) {
 	}
 
 	dt := &dnstap.Dnstap{Message: &dnstap.Message{QueryAddress: []byte{1, 2, 3}, ResponseAddress: []byte{4, 5, 6}}}
-	edm.pseudonymiseDnstap(dt)
+	edm.testPseudonymiseDnstap(dt)
 	if !bytes.Equal(dt.Message.QueryAddress, []byte{0, 0, 0}) || !bytes.Equal(dt.Message.ResponseAddress, []byte{0, 0, 0}) {
 		t.Fatalf("invalid dnstap addresses were not zeroed: %#v", dt.Message)
 	}
@@ -2564,10 +2556,11 @@ func TestRunMinimiserParseAndIgnoreFlows(t *testing.T) {
 	}
 	var builder netipx.IPSetBuilder
 	builder.AddPrefix(netip.MustParsePrefix("198.51.100.20/32"))
-	edm.ignoredClientsIPSet, err = builder.IPSet()
+	ipset, err := builder.IPSet()
 	if err != nil {
 		t.Fatal(err)
 	}
+	edm.ignoredClientsIPSet.Store(ipset)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -2579,10 +2572,11 @@ func TestRunMinimiserParseAndIgnoreFlows(t *testing.T) {
 	edm.reloadMinimiserConfigCh = []chan struct{}{make(chan struct{}, 1)}
 	edm.newQnamePublisherCh = make(chan *protocols.NewQnameJSON)
 	edm.sessionCollectorCh = make(chan *sessionData)
-	edm.ignoredClientsIPSet, err = builder.IPSet()
+	ipset, err = builder.IPSet()
 	if err != nil {
 		t.Fatal(err)
 	}
+	edm.ignoredClientsIPSet.Store(ipset)
 	wg.Add(1)
 	go edm.runMinimiser(0, &wg, cache, db, nil, defaultLabelLimit, wkd)
 	edm.inputChannel <- marshaledDnstap(t, testDnstapMessage(t, dnstap.Message_CLIENT_RESPONSE, dnstap.SocketFamily_INET, packedDNSMsg(t, "ignored.example.", dns.TypeA, dns.RcodeSuccess)))

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -240,7 +240,7 @@ func TestWKD(t *testing.T) {
 	for _, test := range wkdDawgIndexTests {
 		m := new(dns.Msg)
 		m.SetQuestion(test.domain, dns.TypeA)
-		i, suffixMatch := getDawgIndex(wkd.dawgFinder, m.Question[0].Name)
+		i, suffixMatch := getDawgIndex(wkd.snap.Load().dawgFinder, m.Question[0].Name)
 
 		if test.found && i == dawgNotFound {
 			t.Fatalf("%s: expected match %s, but was not found", test.name, test.domain)
@@ -343,7 +343,7 @@ func TestRotateTrackerUsesSafeDawgLoader(t *testing.T) {
 		t.Fatalf("Chtimes: %s", err)
 	}
 
-	if _, err := wkd.rotateTracker(edm, dawgFile, time.Now()); !errors.Is(err, errEmptyDawgFile) {
+	if _, err := wkd.rotateTracker(edm, dawgFile, time.Time{}, time.Now()); !errors.Is(err, errEmptyDawgFile) {
 		t.Fatalf("rotateTracker error have: %v, want: %v", err, errEmptyDawgFile)
 	}
 }
@@ -601,7 +601,7 @@ func TestIgnoredClientIPsEmpty(t *testing.T) {
 	expectedValidNumCIDRs := 2
 
 	// Make sure we actually got anything loaded from the file with content
-	if edm.ignoredClientsIPSet == nil {
+	if edm.ignoredClientsIPSet.Load() == nil {
 		t.Fatalf("edm.ignoredClientsIPSet parsed from '%s' should not be nil", testdataFile)
 	}
 	if edm.getNumIgnoredClientCIDRs() < 1 {
@@ -622,8 +622,8 @@ func TestIgnoredClientIPsEmpty(t *testing.T) {
 		t.Fatalf("unexpected number of CIDRs parsed from '%s': have: %d, want: %d", testdataFile, edm.getNumIgnoredClientCIDRs(), expectedNumCIDRs)
 	}
 
-	if edm.ignoredClientsIPSet != nil {
-		t.Fatalf("edm.ignoredClientsIPSet should be nil, have: %#v", edm.ignoredClientsIPSet)
+	if got := edm.ignoredClientsIPSet.Load(); got != nil {
+		t.Fatalf("edm.ignoredClientsIPSet should be nil, have: %#v", got)
 	}
 
 	ipLookupTests := []struct {
@@ -790,8 +790,8 @@ func TestIgnoredQuestionNamesValid(t *testing.T) {
 		t.Fatalf("unable to parse testdata: %s", err)
 	}
 
-	if edm.ignoredQuestions.NumAdded() != expectedNumNames {
-		t.Fatalf("unexpected number of names parsed from '%s': have: %d, want: %d", testdataFile1, edm.ignoredQuestions.NumAdded(), expectedNumNames)
+	if edm.ignoredQuestions.Load().finder.NumAdded() != expectedNumNames {
+		t.Fatalf("unexpected number of names parsed from '%s': have: %d, want: %d", testdataFile1, edm.ignoredQuestions.Load().finder.NumAdded(), expectedNumNames)
 	}
 
 	questionLookupTests := []struct {
@@ -858,8 +858,8 @@ func TestIgnoredQuestionNamesValid(t *testing.T) {
 		t.Fatalf("unable to parse testdata: %s", err)
 	}
 
-	if edm.ignoredQuestions.NumAdded() != expectedNumNames {
-		t.Fatalf("unexpected number of names parsed from '%s': have: %d, want: %d", testdataFile2, edm.ignoredQuestions.NumAdded(), expectedNumNames)
+	if edm.ignoredQuestions.Load().finder.NumAdded() != expectedNumNames {
+		t.Fatalf("unexpected number of names parsed from '%s': have: %d, want: %d", testdataFile2, edm.ignoredQuestions.Load().finder.NumAdded(), expectedNumNames)
 	}
 
 	questionLookupTests2 := []struct {
@@ -934,8 +934,8 @@ func TestIgnoredQuestionNamesEmpty(t *testing.T) {
 	// Magic value counted by hand
 	expectedNumNames := 2
 
-	if edm.ignoredQuestions.NumAdded() != expectedNumNames {
-		t.Fatalf("unexpected number of names parsed from '%s': have: %d, want: %d", testdataFile, edm.ignoredQuestions.NumAdded(), expectedNumNames)
+	if edm.ignoredQuestions.Load().finder.NumAdded() != expectedNumNames {
+		t.Fatalf("unexpected number of names parsed from '%s': have: %d, want: %d", testdataFile, edm.ignoredQuestions.Load().finder.NumAdded(), expectedNumNames)
 	}
 
 	testdataFile = "testdata/ignored-question-names.empty.dawg"
@@ -945,8 +945,8 @@ func TestIgnoredQuestionNamesEmpty(t *testing.T) {
 		t.Fatalf("unable to parse testdata: %s", err)
 	}
 
-	if edm.ignoredQuestions != nil {
-		t.Fatalf("edm.ignoredQuestions should be nil: have: %#v", edm.ignoredQuestions)
+	if edm.ignoredQuestions.Load() != nil {
+		t.Fatalf("edm.ignoredQuestions should be nil: have: %#v", edm.ignoredQuestions.Load())
 	}
 
 	// Try to look for things that was present in the initial valid data
@@ -1009,8 +1009,8 @@ func TestIgnoredQuestionNamesUnset(t *testing.T) {
 	// Magic value counted by hand
 	expectedNumNames := 2
 
-	if edm.ignoredQuestions.NumAdded() != expectedNumNames {
-		t.Fatalf("unexpected number of names parsed from '%s': have: %d, want: %d", testdataFile, edm.ignoredQuestions.NumAdded(), expectedNumNames)
+	if edm.ignoredQuestions.Load().finder.NumAdded() != expectedNumNames {
+		t.Fatalf("unexpected number of names parsed from '%s': have: %d, want: %d", testdataFile, edm.ignoredQuestions.Load().finder.NumAdded(), expectedNumNames)
 	}
 
 	// Now set an empty filename
@@ -1020,8 +1020,8 @@ func TestIgnoredQuestionNamesUnset(t *testing.T) {
 		t.Fatalf("unable to parse testdata: %s", err)
 	}
 
-	if edm.ignoredQuestions != nil {
-		t.Fatalf("edm.ignoredQuestions should be nil: have: %#v", edm.ignoredQuestions)
+	if edm.ignoredQuestions.Load() != nil {
+		t.Fatalf("edm.ignoredQuestions should be nil: have: %#v", edm.ignoredQuestions.Load())
 	}
 
 	// Try to look for things that was present in the initial valid data
@@ -1342,14 +1342,14 @@ func TestPseudonymiseDnstap(t *testing.T) {
 
 	edm := newTestDnstapMinimiser(t, defaultTC)
 
-	if edm.cryptopanCache != nil {
-		if edm.cryptopanCache.Len() != 0 {
-			t.Fatalf("there should be no entries in newly initialised cryptopan cache but it contains items: %d", edm.cryptopanCache.Len())
+	if edm.testCryptopanCache() != nil {
+		if edm.testCryptopanCache().Len() != 0 {
+			t.Fatalf("there should be no entries in newly initialised cryptopan cache but it contains items: %d", edm.testCryptopanCache().Len())
 		}
 	}
 
-	edm.pseudonymiseDnstap(dt4)
-	edm.pseudonymiseDnstap(dt6)
+	edm.testPseudonymiseDnstap(dt4)
+	edm.testPseudonymiseDnstap(dt6)
 
 	pseudoQueryAddr4, ok := netip.AddrFromSlice(dt4.Message.QueryAddress)
 	if !ok {
@@ -1405,13 +1405,13 @@ func TestPseudonymiseDnstap(t *testing.T) {
 		t.Fatalf("pseudonymised IPv6 resp address %s is not the expected address %s", pseudoRespAddr6, expectedPseudoRespAddr6)
 	}
 
-	if edm.cryptopanCache != nil {
-		if edm.cryptopanCache.Len() == 0 {
+	if edm.testCryptopanCache() != nil {
+		if edm.testCryptopanCache().Len() == 0 {
 			t.Fatalf("there should be entries in the cryptopan cache but it is empty")
 		}
 
 		// Verify the entry in the cache is the same as the one we got back
-		cachedPseudoQueryAddr4, ok := edm.cryptopanCache.Get(origQueryAddr4)
+		cachedPseudoQueryAddr4, ok := edm.testCryptopanCache().Get(origQueryAddr4)
 		if !ok {
 			t.Fatalf("unable to lookup IPv4 query address %s in cache", origQueryAddr4)
 		}
@@ -1419,7 +1419,7 @@ func TestPseudonymiseDnstap(t *testing.T) {
 			t.Fatalf("cached pseudonymised IPv4 query address %s is not the same as the calculated address %s", cachedPseudoQueryAddr4, pseudoQueryAddr4)
 		}
 
-		cachedPseudoRespAddr4, ok := edm.cryptopanCache.Get(origRespAddr4)
+		cachedPseudoRespAddr4, ok := edm.testCryptopanCache().Get(origRespAddr4)
 		if !ok {
 			t.Fatalf("unable to lookup IPv4 response address %s in cache", origRespAddr4)
 		}
@@ -1427,7 +1427,7 @@ func TestPseudonymiseDnstap(t *testing.T) {
 			t.Fatalf("cached pseudonymised IPv4 response address %s is not the same as the calculated address %s", cachedPseudoRespAddr4, pseudoRespAddr4)
 		}
 
-		cachedPseudoQueryAddr6, ok := edm.cryptopanCache.Get(origQueryAddr6)
+		cachedPseudoQueryAddr6, ok := edm.testCryptopanCache().Get(origQueryAddr6)
 		if !ok {
 			t.Fatalf("unable to lookup IPv6 query address %s in cache", origQueryAddr6)
 		}
@@ -1435,7 +1435,7 @@ func TestPseudonymiseDnstap(t *testing.T) {
 			t.Fatalf("cached pseudonymised IPv6 query address %s is not the same as the calculated address %s", cachedPseudoQueryAddr6, pseudoQueryAddr6)
 		}
 
-		cachedPseudoRespAddr6, ok := edm.cryptopanCache.Get(origRespAddr6)
+		cachedPseudoRespAddr6, ok := edm.testCryptopanCache().Get(origRespAddr6)
 		if !ok {
 			t.Fatalf("unable to lookup IPv6 response address %s in cache", origRespAddr6)
 		}
@@ -1444,13 +1444,13 @@ func TestPseudonymiseDnstap(t *testing.T) {
 		}
 	}
 
-	if edm.cryptopanCache != nil {
-		t.Logf("number of pseudonymisation cache entries before reset: %d", edm.cryptopanCache.Len())
+	if edm.testCryptopanCache() != nil {
+		t.Logf("number of pseudonymisation cache entries before reset: %d", edm.testCryptopanCache().Len())
 	}
 
-	if edm.cryptopanCache != nil {
-		for _, key := range edm.cryptopanCache.Keys() {
-			value, ok := edm.cryptopanCache.Get(key)
+	if edm.testCryptopanCache() != nil {
+		for _, key := range edm.testCryptopanCache().Keys() {
+			value, ok := edm.testCryptopanCache().Get(key)
 			if !ok {
 				t.Fatalf("unable to extract value for key before reset: %s", key)
 			}
@@ -1465,9 +1465,13 @@ func TestPseudonymiseDnstap(t *testing.T) {
 		t.Fatalf("unable to call edm.SetCryptopan: %s", err)
 	}
 
-	if edm.cryptopanCache != nil {
-		if edm.cryptopanCache.Len() != 0 {
-			t.Fatalf("there should be no cache entries in replaced cryptopan cache but it contains items: %d", edm.cryptopanCache.Len())
+	// Mirror the per-worker cache purge that runMinimiser would do on
+	// detecting a cryptopan generation change.
+	edm.testResetCryptopanCache()
+
+	if edm.testCryptopanCache() != nil {
+		if edm.testCryptopanCache().Len() != 0 {
+			t.Fatalf("there should be no cache entries in replaced cryptopan cache but it contains items: %d", edm.testCryptopanCache().Len())
 		}
 	}
 
@@ -1477,8 +1481,8 @@ func TestPseudonymiseDnstap(t *testing.T) {
 	dt6.Message.QueryAddress = origQueryAddr6.AsSlice()
 	dt6.Message.ResponseAddress = origRespAddr6.AsSlice()
 
-	edm.pseudonymiseDnstap(dt4)
-	edm.pseudonymiseDnstap(dt6)
+	edm.testPseudonymiseDnstap(dt4)
+	edm.testPseudonymiseDnstap(dt6)
 
 	pseudoQueryAddrUpdated4, ok := netip.AddrFromSlice(dt4.Message.QueryAddress)
 	if !ok {
@@ -1539,10 +1543,10 @@ func TestPseudonymiseDnstap(t *testing.T) {
 		t.Fatalf("updated pseudonymised IPv6 resp address %s is not the expected address %s", pseudoRespAddrUpdated6, expectedPseudoRespAddrUpdated6)
 	}
 
-	if edm.cryptopanCache != nil {
-		t.Logf("number of pseudonymisation cache entries before end: %d", edm.cryptopanCache.Len())
-		for _, key := range edm.cryptopanCache.Keys() {
-			value, ok := edm.cryptopanCache.Get(key)
+	if edm.testCryptopanCache() != nil {
+		t.Logf("number of pseudonymisation cache entries before end: %d", edm.testCryptopanCache().Len())
+		for _, key := range edm.testCryptopanCache().Keys() {
+			value, ok := edm.testCryptopanCache().Get(key)
 			if !ok {
 				t.Fatalf("unable to extract value for key before end: %s", key)
 			}
@@ -1557,14 +1561,20 @@ func TestPseudonymiseDnstap(t *testing.T) {
 		t.Fatalf("unable to call edm.SetCryptopan with 0 cache size: %s", err)
 	}
 
+	// Mirror the per-worker cache purge + disable that runMinimiser would
+	// do in production: drop the existing test cache and zero the config
+	// so testCryptopanCache returns nil (uncached path).
+	edm.testResetCryptopanCache()
+	edm.conf.CryptopanAddressEntries = 0
+
 	// Reset the addresses and pseudonymise again with the updated key
 	dt4.Message.QueryAddress = origQueryAddr4.AsSlice()
 	dt4.Message.ResponseAddress = origRespAddr4.AsSlice()
 	dt6.Message.QueryAddress = origQueryAddr6.AsSlice()
 	dt6.Message.ResponseAddress = origRespAddr6.AsSlice()
 
-	edm.pseudonymiseDnstap(dt4)
-	edm.pseudonymiseDnstap(dt6)
+	edm.testPseudonymiseDnstap(dt4)
+	edm.testPseudonymiseDnstap(dt6)
 
 	uncachedPseudoQueryAddr4, ok := netip.AddrFromSlice(dt4.Message.QueryAddress)
 	if !ok {
@@ -1637,7 +1647,7 @@ func BenchmarkPseudonymiseDnstapWithCache4(b *testing.B) {
 				ResponseAddress: origRespAddr4.AsSlice(),
 			},
 		}
-		edm.pseudonymiseDnstap(dt4)
+		edm.testPseudonymiseDnstap(dt4)
 	}
 }
 
@@ -1661,7 +1671,7 @@ func BenchmarkPseudonymiseDnstapWithoutCache4(b *testing.B) {
 				ResponseAddress: origRespAddr4.AsSlice(),
 			},
 		}
-		edm.pseudonymiseDnstap(dt4)
+		edm.testPseudonymiseDnstap(dt4)
 	}
 }
 
@@ -1682,7 +1692,7 @@ func BenchmarkPseudonymiseDnstapWithCache6(b *testing.B) {
 				ResponseAddress: origRespAddr6.AsSlice(),
 			},
 		}
-		edm.pseudonymiseDnstap(dt6)
+		edm.testPseudonymiseDnstap(dt6)
 	}
 }
 
@@ -1706,7 +1716,7 @@ func BenchmarkPseudonymiseDnstapWithoutCache6(b *testing.B) {
 				ResponseAddress: origRespAddr6.AsSlice(),
 			},
 		}
-		edm.pseudonymiseDnstap(dt6)
+		edm.testPseudonymiseDnstap(dt6)
 	}
 }
 

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -296,6 +296,23 @@ func TestWKD(t *testing.T) {
 	}
 }
 
+func TestTimestampsFromFilenameRejectsMalformedNames(t *testing.T) {
+	tests := []string{
+		"dns_histogram.parquet",
+		"dns_histogram-2026-04-30T12-00-00Z.parquet",
+		"dns_histogram-bad_2026-04-30T12-01-00Z.parquet",
+		"dns_histogram-2026-04-30T12-00-00Z_bad.parquet",
+	}
+
+	for _, name := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := timestampsFromFilename(name); err == nil {
+				t.Fatal("timestampsFromFilename returned nil error")
+			}
+		})
+	}
+}
+
 func TestIgnoredClientIPsValid(t *testing.T) {
 	edm := newTestDnstapMinimiser(t, defaultTC)
 

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -313,6 +313,41 @@ func TestTimestampsFromFilenameRejectsMalformedNames(t *testing.T) {
 	}
 }
 
+func TestRotateTrackerUsesSafeDawgLoader(t *testing.T) {
+	dBuilder := dawg.New()
+	dBuilder.Add("example.com.")
+	dFinder := dBuilder.Finish()
+
+	dawgFile := filepath.Join(t.TempDir(), "well-known-domains.dawg")
+	if _, err := dFinder.Save(dawgFile); err != nil {
+		t.Fatalf("Save: %s", err)
+	}
+	fileInfo, err := os.Stat(dawgFile)
+	if err != nil {
+		t.Fatalf("Stat: %s", err)
+	}
+
+	wkd, err := newWellKnownDomainsTracker(dFinder, fileInfo.ModTime())
+	if err != nil {
+		t.Fatalf("newWellKnownDomainsTracker: %s", err)
+	}
+	edm := &dnstapMinimiser{
+		log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	if err := os.WriteFile(dawgFile, nil, 0o600); err != nil {
+		t.Fatalf("WriteFile: %s", err)
+	}
+	nextModTime := fileInfo.ModTime().Add(time.Second)
+	if err := os.Chtimes(dawgFile, nextModTime, nextModTime); err != nil {
+		t.Fatalf("Chtimes: %s", err)
+	}
+
+	if _, err := wkd.rotateTracker(edm, dawgFile, time.Now()); !errors.Is(err, errEmptyDawgFile) {
+		t.Fatalf("rotateTracker error have: %v, want: %v", err, errEmptyDawgFile)
+	}
+}
+
 func TestIgnoredClientIPsValid(t *testing.T) {
 	edm := newTestDnstapMinimiser(t, defaultTC)
 

--- a/pkg/runner/test_helpers_test.go
+++ b/pkg/runner/test_helpers_test.go
@@ -1,0 +1,60 @@
+package runner
+
+import (
+	"net/netip"
+	"sync"
+
+	dnstap "github.com/dnstap/golang-dnstap"
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+// testPseudonymiseDnstap is the test-side equivalent of the producer
+// hot path. pseudonymiseDnstap takes the per-worker cache + cryptopan
+// snapshot as parameters; tests don't run inside a real worker so they
+// need their own cache. We give each *dnstapMinimiser instance one shared
+// cache via a sync.Map keyed by the minimiser pointer, so repeated test
+// calls accumulate hits like a single worker would.
+//
+// This is purely a test convenience - production code does not use it.
+var testCryptopanCaches sync.Map // map[*dnstapMinimiser]*lru.Cache[netip.Addr, netip.Addr]
+
+func (edm *dnstapMinimiser) testPseudonymiseDnstap(dt *dnstap.Dnstap) {
+	cache := edm.testCryptopanCache()
+	edm.pseudonymiseDnstap(dt, edm.cryptopan.Load(), cache)
+}
+
+// testCryptopanCache returns the shared per-edm-instance cache, creating
+// it lazily so callers don't have to set it up. cacheEntries is read from
+// the current config; 0 disables caching, mirroring production behaviour.
+func (edm *dnstapMinimiser) testCryptopanCache() *lru.Cache[netip.Addr, netip.Addr] {
+	conf := edm.getConfig()
+	if conf.CryptopanAddressEntries == 0 {
+		return nil
+	}
+	if c, ok := testCryptopanCaches.Load(edm); ok {
+		return c.(*lru.Cache[netip.Addr, netip.Addr])
+	}
+	c, err := lru.New[netip.Addr, netip.Addr](conf.CryptopanAddressEntries)
+	if err != nil {
+		panic(err)
+	}
+	actual, _ := testCryptopanCaches.LoadOrStore(edm, c)
+	return actual.(*lru.Cache[netip.Addr, netip.Addr])
+}
+
+// testResetCryptopanCache drops the test-side cache for edm. Used by
+// tests after setCryptopan to mirror the per-worker Purge that
+// runMinimiser does on cryptopanGen change.
+func (edm *dnstapMinimiser) testResetCryptopanCache() {
+	testCryptopanCaches.Delete(edm)
+}
+
+func cleanupTestMinimiser(edm *dnstapMinimiser) {
+	if edm.stop != nil {
+		edm.stop()
+	}
+	if edm.fsWatcher != nil {
+		_ = edm.fsWatcher.Close()
+		edm.fsWatcher = nil
+	}
+}


### PR DESCRIPTION
Combines four coupled `runner` fixes around data-collection / rotation / reload (overlapping code, must merge together) into one PR — supersedes #174, #181, #183, #195.

- **#174** — `timestampsFromFilename` length guards (no index panic on malformed names).
- **#181** — `rotateTracker` uses the safe `loadDawgFile` helper (guards zero-byte DAWG files).
- **#183** — flush pending session + histogram data on shutdown; `startTime` threaded through `flushSessions`/`rotateTracker`/`rotateCollectedData`.
- **#195** — lock-free atomic reload snapshots (`atomic.Pointer` for cryptopan/ignored*/well-known-domains).

Integration note: `rotateTracker` now combines all three of `loadDawgFile` (#181), `startTime` threading (#183), and the atomic snapshot (#195); `flushHistogram` reads `wkd.snap.Load().dawgFinder`. Each fix is a separate commit. Verified: `go build`, `go vet`, `staticcheck`, `golangci-lint`, `go test -race ./...` all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive concurrency and behavioral tests covering atomic reloads, cryptographic key rotation, ignore-list semantics, WKD/DAWG behavior, parquet rotation, data-collector shutdown/flush, deterministic key derivation, and a parallel benchmark; included shared test helpers for pseudonymisation caching.

* **Refactor**
  * Reduced lock contention by switching hot-path state to atomic snapshots and per-worker caches; improved rotation, interval handling, and cache/rotation coordination for session/histogram/parquet writing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->