### PR TITLE
fix(runner): tag well-known-domains-file and disable-session-files reloadable

### DIFF
--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -18,7 +18,7 @@ const defaultLabelLimit = 10
 // flags in pkg/cmd. Validation rules are enforced by [Config.Validate].
 type Config struct {
 	ConfigFile                    string `toml:"config-file"`
-	DisableSessionFiles           bool   `toml:"disable-session-files"`
+	DisableSessionFiles           bool   `toml:"disable-session-files" reload:"true"`
 	DisableHistogramSender        bool   `toml:"disable-histogram-sender" reload:"true"`
 	DisableMQTT                   bool   `toml:"disable-mqtt"`
 	DisableMQTTFilequeue          bool   `toml:"disable-mqtt-filequeue"`
@@ -32,7 +32,7 @@ type Config struct {
 	InputTLSClientCAFile          string `toml:"input-tls-client-ca-file"`
 	CryptopanKey                  string `toml:"cryptopan-key" reload:"true"`
 	CryptopanKeySalt              string `toml:"cryptopan-key-salt" reload:"true"`
-	WellKnownDomainsFile          string `toml:"well-known-domains-file"`
+	WellKnownDomainsFile          string `toml:"well-known-domains-file" reload:"true"`
 	HistogramHLLExplicitThreshold int    `toml:"histogram-hll-explicit-threshold"`
 	IgnoredClientIPsFile          string `toml:"ignored-client-ips-file" reload:"true"`
 	IgnoredQuestionNamesFile      string `toml:"ignored-question-names-file" reload:"true"`

--- a/pkg/runner/config_reload_test.go
+++ b/pkg/runner/config_reload_test.go
@@ -231,7 +231,9 @@ func TestConfigUpdaterBranches(t *testing.T) {
 			next.WellKnownDomainsFile = "other-well-known.dawg"
 			next.DisableSessionFiles = !startConf.DisableSessionFiles
 			runConfigUpdaterUntil(t, edm, &sequenceConfiger{configs: []Config{next}}, func() bool {
-				return edm.getConfig().WellKnownDomainsFile == "other-well-known.dawg"
+				got := edm.getConfig()
+				return got.WellKnownDomainsFile == next.WellKnownDomainsFile &&
+					got.DisableSessionFiles == next.DisableSessionFiles
 			})
 			if strings.Contains(buf.String(), "requires restart") {
 				t.Fatalf("toggling reloadable fields logged a restart warning: %s", buf.String())

--- a/pkg/runner/config_reload_test.go
+++ b/pkg/runner/config_reload_test.go
@@ -216,6 +216,29 @@ func TestConfigUpdaterBranches(t *testing.T) {
 		})
 	})
 
+	t.Run("reloadable fields do not warn", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			buf := &syncBuf{}
+			edm := newSynctestDnstapMinimiser(t, defaultTC)
+			edm.log = slog.New(slog.NewJSONHandler(buf, nil))
+
+			// well-known-domains-file (the DAWG, re-read at the next
+			// rotation) and disable-session-files (the minimiser worker
+			// re-reads it live) both carry reload:"true", so changing them
+			// must not log the "requires restart" warning.
+			startConf := edm.getConfig()
+			next := startConf
+			next.WellKnownDomainsFile = "other-well-known.dawg"
+			next.DisableSessionFiles = !startConf.DisableSessionFiles
+			runConfigUpdaterUntil(t, edm, &sequenceConfiger{configs: []Config{next}}, func() bool {
+				return edm.getConfig().WellKnownDomainsFile == "other-well-known.dawg"
+			})
+			if strings.Contains(buf.String(), "requires restart") {
+				t.Fatalf("toggling reloadable fields logged a restart warning: %s", buf.String())
+			}
+		})
+	})
+
 	t.Run("config provider error keeps old config", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			buf := &syncBuf{}


### PR DESCRIPTION
## What

Two config keys are already re-applied on `SIGHUP` but were missing the `reload:"true"` struct tag, so changing either and reloading logged a misleading **"modified configuration requires restart"** warning even though the change took effect:

- **`well-known-domains-file`** — the DAWG is re-read at the next histogram rotation (`applyUpdate` sets `dawgReloadRequested`; the data collector swaps it in `wkd.go`). The README already documents the DAWG as reloadable, so the code now matches the docs.
- **`disable-session-files`** — the minimiser worker re-reads it live on the reload signal (`minimiser.go`) and explicitly logs enabling/disabling session-file writing.

This tags both so the restart warning fires only for keys that genuinely need a restart.

## Audit

I traced the whole reload path (`applyUpdate` and every consumer: `setCryptopan`, `setIgnored*`, `load{HTTP,MQTT}ClientCert`, `setupHistogramSender`, the DAWG reload, the minimiser worker, and the histogram-sender goroutine) in both directions:

- **Reloaded but untagged** → the two fields fixed here.
- **Tagged but not reloaded** → none. All other `reload:"true"` fields (`pebble-sync`, `disable-histogram-sender`, cryptopan key/salt, both ignore-list files, both MQTT and both HTTP client-cert files) are genuinely re-applied.
- Untagged fields the warning fires for do require a restart (e.g. `cryptopan-address-entries` is only re-applied as a side effect when the key or salt also changes, so it stays untagged).

## Test

Adds a `TestConfigUpdaterBranches` case asserting that a reload changing only these two fields logs no "requires restart" warning. Verified it fails without the tag additions and passes with them.

Gate: gofmt, gofumpt, go vet, staticcheck, go build, `go test -race ./...`, golangci-lint — all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configuration settings `disable-session-files` and `well-known-domains-file` are now reloadable.
  * Changes to these settings can be applied immediately during a config reload, without restarting the application.

* **Tests**
  * Added coverage to ensure reloadable fields apply updated values and do not produce “requires restart” warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->