### PR TITLE
Improve CLI help output

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"errors"
 	"flag"
 	"fmt"
@@ -8,6 +9,8 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+
+	"github.com/dnstapir/edm/pkg/runner"
 )
 
 // envPrefix namespaces the environment variables read by [Execute]: every
@@ -53,15 +56,23 @@ func dispatch(args []string, outW, errW io.Writer) (err error) {
 	rootFS.SetOutput(errW)
 	var rootCfgFile string
 	rootFS.StringVar(&rootCfgFile, "config-file", "", "config file for sensitive information (default is $HOME/.dnstapir-edm.toml)")
-	rootFS.Usage = func() { printUsage(errW, rootFS) }
+	var usage bytes.Buffer
+	rootFS.Usage = func() {
+		usage.Reset()
+		printUsage(&usage, rootFS)
+	}
 
 	// Stdlib flag parsing stops at the first non-flag argument, leaving the
 	// subcommand and its flags in rootFS.Args().
 	err = rootFS.Parse(args)
 	if errors.Is(err, flag.ErrHelp) {
-		return nil
+		_, err = io.Copy(outW, &usage)
+		return
 	}
 	if err != nil {
+		if _, copyErr := io.Copy(errW, &usage); copyErr != nil {
+			err = errors.Join(err, copyErr)
+		}
 		return err
 	}
 
@@ -73,7 +84,7 @@ func dispatch(args []string, outW, errW io.Writer) (err error) {
 
 	switch rest[0] {
 	case "run":
-		err = runRun(rest[1:], rootCfgFile, errW)
+		err = runRun(rest[1:], rootCfgFile, outW, errW)
 	default:
 		fmt.Fprintf(errW, "unknown command %q\n\n", rest[0])
 		printUsage(errW, rootFS)
@@ -83,7 +94,11 @@ func dispatch(args []string, outW, errW io.Writer) (err error) {
 }
 
 // printUsage writes the top-level help text: the tool description, the
-// available commands and the root flags.
+// available commands, the root flags and the full set of "run" command flags.
+//
+// The "run" command carries every operational flag, so its flagset is built
+// and printed here too; that keeps "help"/"-help" documenting the complete
+// flag set and prevents the help text from drifting from [newRunFlagSet].
 func printUsage(w io.Writer, rootFS *flag.FlagSet) {
 	fmt.Fprintln(w, `dnstapir-edm is a tool for reading dnstap data, pseudonymizing IP addresses and
 outputting minimised output data.
@@ -98,6 +113,29 @@ Commands:
 Flags:`)
 	rootFS.SetOutput(w)
 	rootFS.PrintDefaults()
+
+	fmt.Fprintln(w, "\nRun command flags:")
+	runFS := newRunFlagSet(new(runner.Config))
+	printFlagDefaultsExcept(w, runFS, "config-file")
+}
+
+// printFlagDefaultsExcept prints a flag set using the stdlib formatter while
+// omitting names that are documented elsewhere in the same usage text.
+func printFlagDefaultsExcept(w io.Writer, fs *flag.FlagSet, excluded ...string) {
+	skip := make(map[string]struct{}, len(excluded))
+	for _, name := range excluded {
+		skip[name] = struct{}{}
+	}
+
+	filtered := flag.NewFlagSet(fs.Name(), flag.ContinueOnError)
+	filtered.SetOutput(w)
+	fs.VisitAll(func(f *flag.Flag) {
+		if _, ok := skip[f.Name]; ok {
+			return
+		}
+		filtered.Var(f.Value, f.Name, f.Usage)
+	})
+	filtered.PrintDefaults()
 }
 
 // resolveConfigPath returns the config file to use: explicit when non-empty,

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -57,37 +57,46 @@ func TestDispatch(t *testing.T) {
 	edmLogger, edmLoggerLevel = testLogger()
 
 	tests := []struct {
-		name       string
-		args       []string
-		wantErr    error
-		wantOutSub string
-		wantErrSub string
+		name         string
+		args         []string
+		wantErr      error
+		wantOutSub   []string
+		wantErrSub   []string
+		wantErrEmpty bool
 	}{
 		{
-			name:       "no args prints usage",
+			name:       "no args prints usage with run flags",
 			args:       nil,
-			wantOutSub: "Usage:",
+			wantOutSub: []string{"Usage:", "cryptopan-key"},
 		},
 		{
-			name:       "help prints usage",
+			name:       "help prints usage with run flags",
 			args:       []string{"help"},
-			wantOutSub: "Usage:",
+			wantOutSub: []string{"Usage:", "cryptopan-key"},
 		},
 		{
-			name:       "root --help prints usage on stderr",
-			args:       []string{"--help"},
-			wantErrSub: "Usage:",
+			name:         "root -help prints usage with run flags on stdout",
+			args:         []string{"-help"},
+			wantOutSub:   []string{"Usage:", "cryptopan-key"},
+			wantErrEmpty: true,
 		},
 		{
-			name:       "run --help prints run flags",
-			args:       []string{"run", "--help"},
-			wantErrSub: "cryptopan-key",
+			name:         "root --help prints usage with run flags on stdout",
+			args:         []string{"--help"},
+			wantOutSub:   []string{"Usage:", "cryptopan-key"},
+			wantErrEmpty: true,
+		},
+		{
+			name:         "run --help prints run flags on stdout",
+			args:         []string{"run", "--help"},
+			wantOutSub:   []string{"cryptopan-key"},
+			wantErrEmpty: true,
 		},
 		{
 			name:       "unknown command errors",
 			args:       []string{"frobnicate"},
 			wantErr:    errUnknownCommand,
-			wantErrSub: `unknown command "frobnicate"`,
+			wantErrSub: []string{`unknown command "frobnicate"`},
 		},
 	}
 
@@ -104,11 +113,18 @@ func TestDispatch(t *testing.T) {
 			if tc.wantErr == nil && err != nil {
 				t.Fatalf("dispatch() = %v, want nil", err)
 			}
-			if tc.wantOutSub != "" && !strings.Contains(outW.String(), tc.wantOutSub) {
-				t.Fatalf("stdout %q does not contain %q", outW.String(), tc.wantOutSub)
+			for _, want := range tc.wantOutSub {
+				if !strings.Contains(outW.String(), want) {
+					t.Fatalf("stdout %q does not contain %q", outW.String(), want)
+				}
 			}
-			if tc.wantErrSub != "" && !strings.Contains(errW.String(), tc.wantErrSub) {
-				t.Fatalf("stderr %q does not contain %q", errW.String(), tc.wantErrSub)
+			for _, want := range tc.wantErrSub {
+				if !strings.Contains(errW.String(), want) {
+					t.Fatalf("stderr %q does not contain %q", errW.String(), want)
+				}
+			}
+			if tc.wantErrEmpty && errW.Len() != 0 {
+				t.Fatalf("stderr = %q, want empty", errW.String())
 			}
 		})
 	}
@@ -154,7 +170,7 @@ func TestConfigFileNotSettableViaEnv(t *testing.T) {
 	t.Setenv("DNSTAPIR_EDM_CONFIG_FILE", bogus)
 
 	// A root-level --config-file must win over the env var, not be shadowed.
-	provider, err := buildRunProvider(nil, configFile, io.Discard)
+	provider, err := buildRunProvider(nil, configFile, io.Discard, io.Discard)
 	if err != nil {
 		t.Fatalf("buildRunProvider: %s", err)
 	}
@@ -165,7 +181,7 @@ func TestConfigFileNotSettableViaEnv(t *testing.T) {
 	// With no --config-file at all, the env var is ignored and the path falls
 	// back to the home default rather than the env value.
 	userHomeDir = func() (string, error) { return "/home/tester", nil }
-	provider, err = buildRunProvider(nil, "", io.Discard)
+	provider, err = buildRunProvider(nil, "", io.Discard, io.Discard)
 	if err != nil {
 		t.Fatalf("buildRunProvider: %s", err)
 	}
@@ -280,7 +296,7 @@ func TestBuildRunProviderPrecedence(t *testing.T) {
 			}
 			configFile := writeTestConfig(t, tc.extra)
 
-			provider, err := buildRunProvider(append([]string{"--config-file", configFile}, tc.args...), "", io.Discard)
+			provider, err := buildRunProvider(append([]string{"--config-file", configFile}, tc.args...), "", io.Discard, io.Discard)
 			if err != nil {
 				t.Fatalf("buildRunProvider: %s", err)
 			}
@@ -300,7 +316,7 @@ func TestBuildRunProviderOverridesSurviveReload(t *testing.T) {
 	configFile := writeTestConfig(t, "debug = false\ndata-dir = \"/srv/one\"\n")
 	t.Setenv("DNSTAPIR_EDM_DEBUG", "true")
 
-	provider, err := buildRunProvider([]string{"--config-file", configFile, "--data-dir", "/srv/cli"}, "", io.Discard)
+	provider, err := buildRunProvider([]string{"--config-file", configFile, "--data-dir", "/srv/cli"}, "", io.Discard, io.Discard)
 	if err != nil {
 		t.Fatalf("buildRunProvider: %s", err)
 	}
@@ -336,7 +352,7 @@ func TestBuildRunProviderOverridesSurviveReload(t *testing.T) {
 func TestApplyEnvOverridesInvalidValue(t *testing.T) {
 	t.Setenv("DNSTAPIR_EDM_DEBUG", "release")
 
-	_, err := buildRunProvider(nil, "", io.Discard)
+	_, err := buildRunProvider(nil, "", io.Discard, io.Discard)
 	if err == nil || !strings.Contains(err.Error(), "DNSTAPIR_EDM_DEBUG") {
 		t.Fatalf("buildRunProvider = %v, want error naming DNSTAPIR_EDM_DEBUG", err)
 	}
@@ -348,7 +364,7 @@ func TestBuildRunProviderReportsErrors(t *testing.T) {
 	t.Run("invalid environment value", func(t *testing.T) {
 		t.Setenv("DNSTAPIR_EDM_DEBUG", "release")
 		var errW bytes.Buffer
-		if _, err := buildRunProvider(nil, "", &errW); err == nil {
+		if _, err := buildRunProvider(nil, "", io.Discard, &errW); err == nil {
 			t.Fatal("buildRunProvider succeeded, want error")
 		}
 		if !strings.Contains(errW.String(), "DNSTAPIR_EDM_DEBUG") {
@@ -358,7 +374,7 @@ func TestBuildRunProviderReportsErrors(t *testing.T) {
 
 	t.Run("unexpected argument", func(t *testing.T) {
 		var errW bytes.Buffer
-		if _, err := buildRunProvider([]string{"surprise"}, "", &errW); err == nil {
+		if _, err := buildRunProvider([]string{"surprise"}, "", io.Discard, &errW); err == nil {
 			t.Fatal("buildRunProvider succeeded, want error")
 		}
 		if !strings.Contains(errW.String(), "unexpected argument") {
@@ -371,7 +387,7 @@ func TestBuildRunProviderReportsErrors(t *testing.T) {
 	// non-numeric and the uint16-overflow paths must error and name the flag.
 	t.Run("invalid mqtt-keepalive value", func(t *testing.T) {
 		var errW bytes.Buffer
-		if _, err := buildRunProvider([]string{"--mqtt-keepalive", "not-a-number"}, "", &errW); err == nil {
+		if _, err := buildRunProvider([]string{"--mqtt-keepalive", "not-a-number"}, "", io.Discard, &errW); err == nil {
 			t.Fatal("buildRunProvider succeeded, want error")
 		}
 		if !strings.Contains(errW.String(), "mqtt-keepalive") {
@@ -381,7 +397,7 @@ func TestBuildRunProviderReportsErrors(t *testing.T) {
 
 	t.Run("out-of-range mqtt-keepalive value", func(t *testing.T) {
 		var errW bytes.Buffer
-		if _, err := buildRunProvider([]string{"--mqtt-keepalive", "70000"}, "", &errW); err == nil {
+		if _, err := buildRunProvider([]string{"--mqtt-keepalive", "70000"}, "", io.Discard, &errW); err == nil {
 			t.Fatal("buildRunProvider succeeded with overflowing keepalive, want error")
 		}
 		if !strings.Contains(errW.String(), "mqtt-keepalive") {
@@ -488,16 +504,20 @@ func TestRunMinimiserInitError(t *testing.T) {
 	}
 }
 
-// TestPrintUsageMentionsRunCommand sanity-checks the usage text mentions
-// the pieces users rely on.
+// TestPrintUsageMentionsRunCommand sanity-checks the usage text mentions the
+// pieces users rely on, including the operational "run" flags so the top-level
+// help documents the full flag set rather than only the root flags.
 func TestPrintUsageMentionsRunCommand(t *testing.T) {
 	out := &bytes.Buffer{}
 	rootFS := flag.NewFlagSet("dnstapir-edm", flag.ContinueOnError)
 	rootFS.String("config-file", "", "config file")
 	printUsage(out, rootFS)
-	for _, want := range []string{"run", "help", "config-file"} {
+	for _, want := range []string{"run", "help", "config-file", "cryptopan-key", "data-dir", "mqtt-server", "debug"} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("usage output missing %q:\n%s", want, out.String())
 		}
+	}
+	if got := strings.Count(out.String(), "config-file"); got != 1 {
+		t.Fatalf("usage output contains config-file %d times, want 1:\n%s", got, out.String())
 	}
 }

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
@@ -210,16 +211,21 @@ func overrideFor(name string, src *runner.Config) runner.ConfigOverride {
 // over environment variable over config file over flag default. fs.Visit
 // afterwards enumerates exactly the union of env-set and CLI-set flags, which
 // becomes the immutable override layer re-applied on every config reload.
-func buildRunProvider(args []string, rootCfgFile string, errW io.Writer) (provider *runner.FileConfigProvider, err error) {
+func buildRunProvider(args []string, rootCfgFile string, outW, errW io.Writer) (provider *runner.FileConfigProvider, err error) {
 	// flagConf escapes into the override closures, which outlive this call.
 	flagConf := new(runner.Config)
 	fs := newRunFlagSet(flagConf)
 	fs.SetOutput(errW)
+	var usage bytes.Buffer
+	fs.Usage = func() {
+		usage.Reset()
+		printFlagSetUsage(&usage, fs)
+	}
 
-	// fs.Parse reports parse errors (and usage) on errW itself; the other
-	// failures below do not, so they are reported at the end to avoid a
-	// silent non-zero exit. parseReported tracks the one already-reported
-	// path so it is not printed twice.
+	// fs.Parse reports parse errors on errW itself and captures usage for the
+	// final stdout/stderr decision; the other failures below do not, so they
+	// are reported at the end to avoid a silent non-zero exit. parseReported
+	// tracks the already-reported path so the error is not printed twice.
 	parseReported := false
 	err = applyEnvOverrides(fs)
 	if err == nil {
@@ -251,16 +257,31 @@ func buildRunProvider(args []string, rootCfgFile string, errW io.Writer) (provid
 		provider = runner.NewFileConfigProvider(path, overrides...)
 	}
 
-	if err != nil && !parseReported && !errors.Is(err, flag.ErrHelp) {
+	switch {
+	case errors.Is(err, flag.ErrHelp):
+		if _, copyErr := io.Copy(outW, &usage); copyErr != nil {
+			err = copyErr
+		}
+	case err != nil && parseReported:
+		if _, copyErr := io.Copy(errW, &usage); copyErr != nil {
+			err = errors.Join(err, copyErr)
+		}
+	case err != nil:
 		fmt.Fprintln(errW, err)
 	}
 	return
 }
 
+func printFlagSetUsage(w io.Writer, fs *flag.FlagSet) {
+	fmt.Fprintf(w, "Usage of %s:\n", fs.Name())
+	fs.SetOutput(w)
+	fs.PrintDefaults()
+}
+
 // runRun implements the "run" subcommand.
-func runRun(args []string, rootCfgFile string, errW io.Writer) (err error) {
+func runRun(args []string, rootCfgFile string, outW, errW io.Writer) (err error) {
 	var provider *runner.FileConfigProvider
-	provider, err = buildRunProvider(args, rootCfgFile, errW)
+	provider, err = buildRunProvider(args, rootCfgFile, outW, errW)
 	if errors.Is(err, flag.ErrHelp) {
 		return nil
 	}


### PR DESCRIPTION
## Summary
- include run flags in top-level help while showing `config-file` only once
- route root and run help output to stdout
- extend command tests for help output streams and duplicate flag coverage

## Tests
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Help output is now correctly routed to stdout when using `--help` and to stderr for parse errors.

* **New Features**
  * Help text now displays run command flags and their defaults in a dedicated section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->