### PR TITLE
runner: add EDM's version to aggregate sender's User-Agent

### DIFF
--- a/pkg/runner/aggregate_sender.go
+++ b/pkg/runner/aggregate_sender.go
@@ -13,12 +13,23 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"runtime"
+	"runtime/debug"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/lestrrat-go/jwx/v3/jwk"
 	"github.com/yaronf/httpsign"
 )
+
+var getUserAgent = sync.OnceValue(func() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return fmt.Sprintf("edm/unknown %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+	return fmt.Sprintf("edm/%s %s/%s", bi.Main.Version, runtime.GOOS, runtime.GOARCH)
+})
 
 type realAggregateSender struct {
 	log               *slog.Logger
@@ -145,6 +156,10 @@ func (as realAggregateSender) Send(ctx context.Context, fileName string, ts time
 	// Expected by aggrec, e.g:
 	// Aggregate-Interval: 2023-11-16T09:24:13+01:00/PT45S
 	req.Header.Add("Aggregate-Interval", fmt.Sprintf("%s/%s", ts.Format(time.RFC3339), iso8601Duration(duration)))
+
+	// Add a User-Agent based on what version of EDM we are running, eg:
+	// edm/v0.0.0-20260617090550-63aad075ec62 linux/amd64
+	req.Header.Add("User-Agent", getUserAgent())
 
 	as.log.Info("aggregateSender.send", "filename", fileName, "url", histogramURL)
 	startTime := clock.Now()


### PR DESCRIPTION
I've constructed a User-Agent as follows;

    edm/v0.0.0-20260629141835-28c068c17028+dirty linux/amd64

which uses the same version information that go uses to refer to go modules when a version is missing. Additionally we add the GOOS/GOARCH. This does not correspond to what elsewhere is used as version, but if I'm not mistaken that information was hard to access + that this version tag includes more useful information. The `+dirty` as seen in the example above gets added if the git tree is not clean when the binary was built. 

Question: I couldn't find a good general place to add the construction of the version. Like a internal/helper module. Does a better place exist?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistent, version- and platform-aware request identifier to outgoing telemetry uploads.
  * If version details aren’t available, requests now use a safe fallback identifier automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

closes #246 