### PR TITLE
feat(deploy): add a service that reloads the dnstapir-edm service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,5 +63,6 @@ deb: build versions
 	cp rpm/SOURCES/well-known-domains.dawg deb/etc/dnstapir/edm
 	cp rpm/SOURCES/ignored.dawg deb/etc/dnstapir/edm
 	cp rpm/SOURCES/ignored-ips deb/etc/dnstapir/edm
+	cp rpm/SOURCES/dnstapir-reloader.service deb/usr/lib/systemd/system
 	sed -e "s/@@VERSION@@/$$(cat DEB_VERSION)/g" $(DEB_CONTROL_IN) > $(DEB_CONTROL_OUT)
 	dpkg-deb -b deb dnstapir-edm-$$(cat DEB_VERSION).deb

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test:
 build: export GOSUMDB=sum.golang.org
 build: export GOTOOLCHAIN=auto
 build:
-	CGO_ENABLED=0 go build -ldflags "-X main.version=$(shell test -f VERSION && cat VERSION || echo dev)" github.com/dnstapir/edm/cmd/dnstapir-edm
+	CGO_ENABLED=0 go build -ldflags "-X github.com/dnstapir/edm/pkg/buildinfo.Version=$(shell test -f VERSION && cat VERSION || echo dev)" github.com/dnstapir/edm/cmd/dnstapir-edm
 
 clean: SHELL:=/bin/bash
 clean:

--- a/cmd/dnstapir-edm/main.go
+++ b/cmd/dnstapir-edm/main.go
@@ -7,11 +7,9 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/dnstapir/edm/pkg/buildinfo"
 	"github.com/dnstapir/edm/pkg/cmd"
 )
-
-// version set at build time with -ldflags="-X main.version=v0.0.1"
-var version = "undefined"
 
 // defaultHostname is used when the real hostname cannot be determined.
 const defaultHostname = "dnstapir-edm-hostname-unknown"
@@ -50,7 +48,7 @@ func main() {
 	loggerLevel := new(slog.LevelVar) // Info by default
 
 	// Logger used for all output
-	logger := buildLogger(os.Stderr, loggerLevel, version, resolveHostname(os.Stderr))
+	logger := buildLogger(os.Stderr, loggerLevel, buildinfo.Version, resolveHostname(os.Stderr))
 
 	// This makes any calls to the standard "log" package to use slog as
 	// well

--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -1,0 +1,4 @@
+package buildinfo
+
+// version set at build time with -ldflags="-X github.com/dnstapir/edm/pkg/buildinfo.Version=v0.0.1"
+var Version = "undefined"

--- a/pkg/runner/aggregate_sender.go
+++ b/pkg/runner/aggregate_sender.go
@@ -14,22 +14,15 @@ import (
 	"net/url"
 	"path/filepath"
 	"runtime"
-	"runtime/debug"
 	"strconv"
-	"sync"
 	"time"
 
+	"github.com/dnstapir/edm/pkg/buildinfo"
 	"github.com/lestrrat-go/jwx/v3/jwk"
 	"github.com/yaronf/httpsign"
 )
 
-var getUserAgent = sync.OnceValue(func() string {
-	bi, ok := debug.ReadBuildInfo()
-	if !ok {
-		return fmt.Sprintf("edm/unknown %s/%s", runtime.GOOS, runtime.GOARCH)
-	}
-	return fmt.Sprintf("edm/%s %s/%s", bi.Main.Version, runtime.GOOS, runtime.GOARCH)
-})
+var userAgent = fmt.Sprintf("edm/%s %s/%s", buildinfo.Version, runtime.GOOS, runtime.GOARCH)
 
 type realAggregateSender struct {
 	log               *slog.Logger
@@ -158,8 +151,8 @@ func (as realAggregateSender) Send(ctx context.Context, fileName string, ts time
 	req.Header.Add("Aggregate-Interval", fmt.Sprintf("%s/%s", ts.Format(time.RFC3339), iso8601Duration(duration)))
 
 	// Add a User-Agent based on what version of EDM we are running, eg:
-	// edm/v0.0.0-20260617090550-63aad075ec62 linux/amd64
-	req.Header.Add("User-Agent", getUserAgent())
+	// edm/63aad075ec62baf21f4c0323fdcd55e4d5bb4333 linux/amd64
+	req.Header.Add("User-Agent", userAgent)
 
 	as.log.Info("aggregateSender.send", "filename", fileName, "url", histogramURL)
 	startTime := clock.Now()

--- a/rpm/SOURCES/dnstapir-reloader.service
+++ b/rpm/SOURCES/dnstapir-reloader.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=DNS TAPIR EDM Reloader
+After=dnstapir-renew.service
+
+[Service]
+Type=oneshot
+ExecStart=systemctl reload dnstapir-edm.service
+
+[Install]
+RequiredBy=dnstapir-renew.service

--- a/rpm/dnstapir-edm.spec.in
+++ b/rpm/dnstapir-edm.spec.in
@@ -22,6 +22,7 @@ Source2:       well-known-domains.dawg
 Source3:       ignored.dawg
 Source4:       ignored-ips
 Source5:       dnstapir-edm.sysusers.conf
+Source6:       dnstapir-reloader.service
 BuildRequires: git
 %if 0%{?suse_version}
 BuildRequires: go
@@ -69,6 +70,7 @@ install -m 0664 -D %{SOURCE4} %{buildroot}%{_sysconfdir}/dnstapir/edm/ignored-ip
 
 # Users and Groups
 install -m 0644 -D %{SOURCE5} %{buildroot}%{_sysusersdir}/dnstapir-edm.conf
+install -m 0644 %{SOURCE6} %{buildroot}%{_unitdir}
 
 %files
 %license LICENSE
@@ -85,6 +87,7 @@ install -m 0644 -D %{SOURCE5} %{buildroot}%{_sysusersdir}/dnstapir-edm.conf
 %attr(0664,dnstapir-edm,dnstapir) %{_sysconfdir}/dnstapir/edm/ignored.dawg
 %attr(0664,dnstapir-edm,dnstapir) %{_sysconfdir}/dnstapir/edm/ignored-ips
 %attr(0660,-,dnstapir) %ghost %{_sysconfdir}/dnstapir/dnstapir-edm.toml
+%attr(0644,dnstapir-edm,dnstapir) %{_unitdir}/dnstapir-reloader.service
 
 %attr(0644,root,root) %{_sysusersdir}/dnstapir-edm.conf
 

--- a/rpm/dnstapir-edm.spec.in
+++ b/rpm/dnstapir-edm.spec.in
@@ -83,7 +83,7 @@ install -m 0644 %{SOURCE6} %{buildroot}%{_unitdir}
 
 %attr(0755,dnstapir-edm,dnstapir)                    %{_bindir}/%{name}
 %attr(0644,dnstapir-edm,dnstapir) %config            %{_unitdir}/dnstapir-edm.service
-%attr(0644,dnstapir-edm,dnstapir) %{_unitdir}/dnstapir-reloader.service
+%attr(0644,dnstapir-edm,dnstapir) %config            %{_unitdir}/dnstapir-reloader.service
 %attr(0664,dnstapir-edm,dnstapir) %config(noreplace) %{_sysconfdir}/dnstapir/edm/well-known-domains.dawg
 %attr(0664,dnstapir-edm,dnstapir) %config(noreplace) %{_sysconfdir}/dnstapir/edm/ignored.dawg
 %attr(0664,dnstapir-edm,dnstapir) %config(noreplace) %{_sysconfdir}/dnstapir/edm/ignored-ips

--- a/rpm/dnstapir-edm.spec.in
+++ b/rpm/dnstapir-edm.spec.in
@@ -79,14 +79,14 @@ install -m 0644 -D %{SOURCE5} %{buildroot}%{_sysusersdir}/dnstapir-edm.conf
 %attr(0770,dnstapir-edm,dnstapir) %dir %{_sharedstatedir}/dnstapir/edm/pebble
 %attr(0770,dnstapir-edm,dnstapir) %dir %{_sharedstatedir}/dnstapir/edm/mqtt
 
-%attr(0755,dnstapir-edm,dnstapir) %{_bindir}/%{name}
-%attr(0644,dnstapir-edm,dnstapir) %{_unitdir}/dnstapir-edm.service
-%attr(0664,dnstapir-edm,dnstapir) %{_sysconfdir}/dnstapir/edm/well-known-domains.dawg
-%attr(0664,dnstapir-edm,dnstapir) %{_sysconfdir}/dnstapir/edm/ignored.dawg
-%attr(0664,dnstapir-edm,dnstapir) %{_sysconfdir}/dnstapir/edm/ignored-ips
-%attr(0660,-,dnstapir) %ghost %{_sysconfdir}/dnstapir/dnstapir-edm.toml
+%attr(0755,dnstapir-edm,dnstapir)                    %{_bindir}/%{name}
+%attr(0644,dnstapir-edm,dnstapir) %config            %{_unitdir}/dnstapir-edm.service
+%attr(0664,dnstapir-edm,dnstapir) %config(noreplace) %{_sysconfdir}/dnstapir/edm/well-known-domains.dawg
+%attr(0664,dnstapir-edm,dnstapir) %config(noreplace) %{_sysconfdir}/dnstapir/edm/ignored.dawg
+%attr(0664,dnstapir-edm,dnstapir) %config(noreplace) %{_sysconfdir}/dnstapir/edm/ignored-ips
+%attr(0660,-,dnstapir)            %ghost             %{_sysconfdir}/dnstapir/dnstapir-edm.toml
 
-%attr(0644,root,root) %{_sysusersdir}/dnstapir-edm.conf
+%attr(0644,root,root)                                %{_sysusersdir}/dnstapir-edm.conf
 
 %if %{with sysusers_compat}
 %pre


### PR DESCRIPTION
this service reloads dnstapir-edm.service upon completion of dnstapir-renew.service, ie. after certificate renewals

Partial implementation of #245 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a system service unit that automatically reloads the main EDM service after renewal-related actions, ensuring changes are applied without manual restarts.
* **Bug Fixes**
  * Improved build/version reporting by consistently using the injected build version for runtime logging.
  * Updated the outbound HTTP User-Agent to reliably reflect the build version and target platform.
* **Packaging**
  * Ensured the new reloader unit is included in Debian and RPM systemd installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->