### PR TITLE
runner: make sure that User-Agnet is available on rpm builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test:
 build: export GOSUMDB=sum.golang.org
 build: export GOTOOLCHAIN=auto
 build:
-	CGO_ENABLED=0 go build -ldflags "-X main.version=$(shell test -f VERSION && cat VERSION || echo dev)" github.com/dnstapir/edm/cmd/dnstapir-edm
+	CGO_ENABLED=0 go build -ldflags "-X github.com/dnstapir/edm/pkg/buildinfo.Version=$(shell test -f VERSION && cat VERSION || echo dev)" github.com/dnstapir/edm/cmd/dnstapir-edm
 
 clean: SHELL:=/bin/bash
 clean:

--- a/cmd/dnstapir-edm/main.go
+++ b/cmd/dnstapir-edm/main.go
@@ -7,11 +7,9 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/dnstapir/edm/pkg/buildinfo"
 	"github.com/dnstapir/edm/pkg/cmd"
 )
-
-// version set at build time with -ldflags="-X main.version=v0.0.1"
-var version = "undefined"
 
 // defaultHostname is used when the real hostname cannot be determined.
 const defaultHostname = "dnstapir-edm-hostname-unknown"
@@ -50,7 +48,7 @@ func main() {
 	loggerLevel := new(slog.LevelVar) // Info by default
 
 	// Logger used for all output
-	logger := buildLogger(os.Stderr, loggerLevel, version, resolveHostname(os.Stderr))
+	logger := buildLogger(os.Stderr, loggerLevel, buildinfo.Version, resolveHostname(os.Stderr))
 
 	// This makes any calls to the standard "log" package to use slog as
 	// well

--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -1,0 +1,4 @@
+package buildinfo
+
+// version set at build time with -ldflags="-X github.com/dnstapir/edm/pkg/buildinfo.Version=v0.0.1"
+var Version = "undefined"

--- a/pkg/runner/aggregate_sender.go
+++ b/pkg/runner/aggregate_sender.go
@@ -14,22 +14,15 @@ import (
 	"net/url"
 	"path/filepath"
 	"runtime"
-	"runtime/debug"
 	"strconv"
-	"sync"
 	"time"
 
+	"github.com/dnstapir/edm/pkg/buildinfo"
 	"github.com/lestrrat-go/jwx/v3/jwk"
 	"github.com/yaronf/httpsign"
 )
 
-var getUserAgent = sync.OnceValue(func() string {
-	bi, ok := debug.ReadBuildInfo()
-	if !ok {
-		return fmt.Sprintf("edm/unknown %s/%s", runtime.GOOS, runtime.GOARCH)
-	}
-	return fmt.Sprintf("edm/%s %s/%s", bi.Main.Version, runtime.GOOS, runtime.GOARCH)
-})
+var userAgent = fmt.Sprintf("edm/%s %s/%s", buildinfo.Version, runtime.GOOS, runtime.GOARCH)
 
 type realAggregateSender struct {
 	log               *slog.Logger
@@ -158,8 +151,8 @@ func (as realAggregateSender) Send(ctx context.Context, fileName string, ts time
 	req.Header.Add("Aggregate-Interval", fmt.Sprintf("%s/%s", ts.Format(time.RFC3339), iso8601Duration(duration)))
 
 	// Add a User-Agent based on what version of EDM we are running, eg:
-	// edm/v0.0.0-20260617090550-63aad075ec62 linux/amd64
-	req.Header.Add("User-Agent", getUserAgent())
+	// edm/63aad075ec62baf21f4c0323fdcd55e4d5bb4333 linux/amd64
+	req.Header.Add("User-Agent", userAgent)
 
 	as.log.Info("aggregateSender.send", "filename", fileName, "url", histogramURL)
 	startTime := clock.Now()


### PR DESCRIPTION
When building the rpm-package, the git repo isn't available, hence the version in `debug.ReadBuildInfo()` isn't set properly. Move `main.version` to a separate path `pkg/buildinfo` and use that for the User-Agent.

Fixes: fe8bfca