### PR TITLE
rpm: manage replacement of some changed files in rpm

### DIFF
--- a/rpm/dnstapir-edm.spec.in
+++ b/rpm/dnstapir-edm.spec.in
@@ -79,14 +79,14 @@ install -m 0644 -D %{SOURCE5} %{buildroot}%{_sysusersdir}/dnstapir-edm.conf
 %attr(0770,dnstapir-edm,dnstapir) %dir %{_sharedstatedir}/dnstapir/edm/pebble
 %attr(0770,dnstapir-edm,dnstapir) %dir %{_sharedstatedir}/dnstapir/edm/mqtt
 
-%attr(0755,dnstapir-edm,dnstapir) %{_bindir}/%{name}
-%attr(0644,dnstapir-edm,dnstapir) %{_unitdir}/dnstapir-edm.service
-%attr(0664,dnstapir-edm,dnstapir) %{_sysconfdir}/dnstapir/edm/well-known-domains.dawg
-%attr(0664,dnstapir-edm,dnstapir) %{_sysconfdir}/dnstapir/edm/ignored.dawg
-%attr(0664,dnstapir-edm,dnstapir) %{_sysconfdir}/dnstapir/edm/ignored-ips
-%attr(0660,-,dnstapir) %ghost %{_sysconfdir}/dnstapir/dnstapir-edm.toml
+%attr(0755,dnstapir-edm,dnstapir)                    %{_bindir}/%{name}
+%attr(0644,dnstapir-edm,dnstapir) %config            %{_unitdir}/dnstapir-edm.service
+%attr(0664,dnstapir-edm,dnstapir) %config(noreplace) %{_sysconfdir}/dnstapir/edm/well-known-domains.dawg
+%attr(0664,dnstapir-edm,dnstapir) %config(noreplace) %{_sysconfdir}/dnstapir/edm/ignored.dawg
+%attr(0664,dnstapir-edm,dnstapir) %config(noreplace) %{_sysconfdir}/dnstapir/edm/ignored-ips
+%attr(0660,-,dnstapir)            %ghost             %{_sysconfdir}/dnstapir/dnstapir-edm.toml
 
-%attr(0644,root,root) %{_sysusersdir}/dnstapir-edm.conf
+%attr(0644,root,root)                                %{_sysusersdir}/dnstapir-edm.conf
 
 %if %{with sysusers_compat}
 %pre


### PR DESCRIPTION
* do not replace the well-known-domains.dawg, ignored.dawg, and ignored-ips files
* do replace systemd service if changed, but save the modified version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade handling for the service and bundled data files so locally modified settings are less likely to be overwritten during RPM updates.
  * Preserved existing configuration files more safely by treating key files as upgrade-friendly configuration items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->