### PR TITLE
Make use of new language features of go v1.26

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -29,7 +29,7 @@ jobs:
             type=semver,pattern={{major}}
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.26"
           cache: false
       - uses: ko-build/setup-ko@3aebd0597dc1e9d1a26bcfdb7cbeb19c131d3037 # v0.7
       - run: ko build --base-import-paths --tags "$(printf '%s' "${{ steps.meta.outputs.tags }}" | tr '\n' ',')" github.com/dnstapir/edm/cmd/dnstapir-edm

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dnstapir/edm
 
-go 1.25.6
+go 1.26
 
 require (
 	github.com/cockroachdb/pebble v1.1.5

--- a/pkg/protocols/protocols.go
+++ b/pkg/protocols/protocols.go
@@ -100,22 +100,17 @@ func bitsFromMsg(dns *dns.Msg) uint16 {
 // an empty Qname, nil Qtype and nil Qclass, but other header-derived fields
 // will still be populated.
 func NewQnameEvent(msg *dns.Msg, ts time.Time) NewQnameJSON {
-	bits := bitsFromMsg(msg)
-	flags := int(bits)
-
 	event := NewQnameJSON{
 		Type:      NewQnameJSONType,
 		Timestamp: &ts,
-		Flags:     &flags,
+		Flags:     new(int(bitsFromMsg(msg))),
 		Version:   NewQnameJSONVersion,
 	}
 
 	if len(msg.Question) > 0 {
-		qType := int(msg.Question[0].Qtype)
-		qClass := int(msg.Question[0].Qclass)
 		event.Qname = msg.Question[0].Name
-		event.Qtype = &qType
-		event.Qclass = &qClass
+		event.Qtype = new(int(msg.Question[0].Qtype))
+		event.Qclass = new(int(msg.Question[0].Qclass))
 	}
 
 	return event

--- a/pkg/runner/data_collector_test.go
+++ b/pkg/runner/data_collector_test.go
@@ -181,7 +181,7 @@ func TestDataCollector(t *testing.T) {
 		wg.Add(1)
 		go edm.dataCollector(&wg, wkd, path)
 
-		edm.sessionCollectorCh <- &sessionData{ServerID: ptr("server")}
+		edm.sessionCollectorCh <- &sessionData{ServerID: new("server")}
 		wkd.updateCh <- wkdUpdate{
 			histogramData: histogramData{ACount: 1, OKCount: 1},
 			dawgIndex:     0,

--- a/pkg/runner/dnstap_parse_test.go
+++ b/pkg/runner/dnstap_parse_test.go
@@ -43,8 +43,8 @@ func TestParsePacketAddressFormattingBranches(t *testing.T) {
 		dt := &dnstap.Dnstap{
 			Message: &dnstap.Message{
 				ResponseMessage:  []byte{1, 2, 3},
-				ResponseTimeSec:  ptr(uint64(0)),
-				ResponseTimeNsec: ptr(uint32(0)),
+				ResponseTimeSec:  new(uint64(0)),
+				ResponseTimeNsec: new(uint32(0)),
 			},
 		}
 		badMsg, _ := edm.parsePacket(dt, false)

--- a/pkg/runner/histogram_test.go
+++ b/pkg/runner/histogram_test.go
@@ -196,9 +196,9 @@ func TestHistogramWriter(t *testing.T) {
 
 	hd := histogramData{
 		dnsLabels: dnsLabels{
-			Label0: ptr("com"),
-			Label1: ptr("example"),
-			Label2: ptr("www"),
+			Label0: new("com"),
+			Label1: new("example"),
+			Label2: new("www"),
 		},
 		StartTime:             10,
 		ACount:                11,
@@ -274,9 +274,9 @@ func BenchmarkHistogramWriter(b *testing.B) {
 
 	hd := histogramData{
 		dnsLabels: dnsLabels{
-			Label0: ptr("com"),
-			Label1: ptr("example"),
-			Label2: ptr("www"),
+			Label0: new("com"),
+			Label1: new("example"),
+			Label2: new("www"),
 		},
 		StartTime:             10,
 		ACount:                11,

--- a/pkg/runner/parquet_files_test.go
+++ b/pkg/runner/parquet_files_test.go
@@ -86,8 +86,8 @@ func TestCreateSessionAndHistogramFiles(t *testing.T) {
 	ps := &prevSessions{
 		rotationTime: rotationTime,
 		sessions: []*sessionData{{
-			dnsLabels: dnsLabels{Label0: ptr("com")},
-			ServerID:  ptr("server"),
+			dnsLabels: dnsLabels{Label0: new("com")},
+			ServerID:  new("server"),
 		}},
 	}
 	sessionFile, err := edm.createSessionFile(ps, dataDir)

--- a/pkg/runner/session.go
+++ b/pkg/runner/session.go
@@ -175,46 +175,35 @@ func (edm *DnstapMinimiser) newSession(dt *dnstap.Dnstap, msg *dns.Msg, isQuery 
 	sd := &sessionData{}
 
 	if dt.Message.QueryPort != nil {
-		if *dt.Message.QueryPort > math.MaxInt32 {
-			edm.log.Error("dt.Message.QueryPort is too large for int32, setting port to 0", "value", *dt.Message.QueryPort)
-			var qp int32
-			sd.SourcePort = &qp
-		} else {
-			qp := int32(*dt.Message.QueryPort) // #nosec G115 -- QueryPort is defined as 16-bit number and is used in parquet field with type=INT32, convertedType=UINT_16, https://github.com/securego/gosec/issues/1212#issuecomment-2739574884
-			sd.SourcePort = &qp
+		port := *dt.Message.QueryPort
+		if port > math.MaxInt32 {
+			edm.log.Error("dt.Message.QueryPort is too large for int32, setting port to 0", "value", port)
+			port = 0
 		}
+		sd.SourcePort = new(int32(port)) // #nosec G115 -- QueryPort is defined as 16-bit number and is used in parquet field with type=INT32, convertedType=UINT_16, https://github.com/securego/gosec/issues/1212#issuecomment-2739574884
 	}
 
 	if dt.Message.ResponsePort != nil {
-		if *dt.Message.ResponsePort > math.MaxInt32 {
-			edm.log.Error("dt.Message.ResponsePort is too large for int32, setting port to 0", "value", *dt.Message.ResponsePort)
-			var rp int32
-			sd.DestPort = &rp
-		} else {
-			rp := int32(*dt.Message.ResponsePort) // #nosec G115 -- ResponsePort is defined as 16-bit number and is used in parquet field with type=INT32, convertedType=UINT_16, https://github.com/securego/gosec/issues/1212#issuecomment-2739574884
-			sd.DestPort = &rp
+		port := *dt.Message.ResponsePort
+		if port > math.MaxInt32 {
+			edm.log.Error("dt.Message.ResponsePort is too large for int32, setting port to 0", "value", port)
+			port = 0
 		}
+		sd.DestPort = new(int32(port)) // #nosec G115 -- ResponsePort is defined as 16-bit number and is used in parquet field with type=INT32, convertedType=UINT_16, https://github.com/securego/gosec/issues/1212#issuecomment-2739574884
 	}
 
 	edm.setLabels(dns.SplitDomainName(msg.Question[0].Name), labelLimit, &sd.dnsLabels)
 
 	if isQuery {
-		qms := string(dt.Message.QueryMessage)
-		sd.QueryMessage = &qms
-
-		ms := timestamp.UnixMicro()
-		sd.QueryTime = &ms
+		sd.QueryMessage = new(string(dt.Message.QueryMessage))
+		sd.QueryTime = new(timestamp.UnixMicro())
 	} else {
-		rms := string(dt.Message.ResponseMessage)
-		sd.ResponseMessage = &rms
-
-		ms := timestamp.UnixMicro()
-		sd.ResponseTime = &ms
+		sd.ResponseMessage = new(string(dt.Message.ResponseMessage))
+		sd.ResponseTime = new(timestamp.UnixMicro())
 	}
 
 	if len(dt.Identity) != 0 {
-		sID := string(dt.Identity)
-		sd.ServerID = &sID
+		sd.ServerID = new(string(dt.Identity))
 	}
 
 	switch dt.Message.GetSocketFamily() {
@@ -224,8 +213,7 @@ func (edm *DnstapMinimiser) newSession(dt *dnstap.Dnstap, msg *dns.Msg, isQuery 
 			if err != nil {
 				edm.log.Error("unable to create uint32 from dt.Message.QueryAddress", "error", err)
 			} else {
-				i32SourceIPInt := int32(sourceIPInt) // #nosec G115 -- Used in parquet struct with convertedType=UINT_32
-				sd.SourceIPv4 = &i32SourceIPInt
+				sd.SourceIPv4 = new(int32(sourceIPInt)) // #nosec G115 -- Used in parquet struct with convertedType=UINT_32
 			}
 		}
 
@@ -234,8 +222,7 @@ func (edm *DnstapMinimiser) newSession(dt *dnstap.Dnstap, msg *dns.Msg, isQuery 
 			if err != nil {
 				edm.log.Error("unable to create uint32 from dt.Message.ResponseAddress", "error", err)
 			} else {
-				i32DestIPInt := int32(destIPInt) // #nosec G115 -- Used in parquet struct with convertedType=UINT_32
-				sd.DestIPv4 = &i32DestIPInt
+				sd.DestIPv4 = new(int32(destIPInt)) // #nosec G115 -- Used in parquet struct with convertedType=UINT_32
 			}
 		}
 	case dnstap.SocketFamily_INET6:
@@ -244,10 +231,8 @@ func (edm *DnstapMinimiser) newSession(dt *dnstap.Dnstap, msg *dns.Msg, isQuery 
 			if err != nil {
 				edm.log.Error("unable to create uint64 variables from dt.Message.QueryAddress", "error", err)
 			} else {
-				i64SourceIntNetwork := int64(sourceIPIntNetwork) // #nosec G115 -- Used in parquet struct with convertedType=UINT_64
-				i64SourceIntHost := int64(sourceIPIntHost)       // #nosec G115 -- Used in parquet struct with convertedType=UINT_64
-				sd.SourceIPv6Network = &i64SourceIntNetwork
-				sd.SourceIPv6Host = &i64SourceIntHost
+				sd.SourceIPv6Network = new(int64(sourceIPIntNetwork)) // #nosec G115 -- Used in parquet struct with convertedType=UINT_64
+				sd.SourceIPv6Host = new(int64(sourceIPIntHost))       // #nosec G115 -- Used in parquet struct with convertedType=UINT_64
 			}
 		}
 
@@ -256,10 +241,8 @@ func (edm *DnstapMinimiser) newSession(dt *dnstap.Dnstap, msg *dns.Msg, isQuery 
 			if err != nil {
 				edm.log.Error("unable to create uint64 variables from dt.Message.ResponseAddress", "error", err)
 			} else {
-				i64dIntNetwork := int64(dipIntNetwork) // #nosec G115 -- Used in parquet struct with convertedType=UINT_64
-				i64dIntHost := int64(dipIntHost)       // #nosec G115 -- Used in parquet struct with convertedType=UINT_64
-				sd.DestIPv6Network = &i64dIntNetwork
-				sd.DestIPv6Host = &i64dIntHost
+				sd.DestIPv6Network = new(int64(dipIntNetwork)) // #nosec G115 -- Used in parquet struct with convertedType=UINT_64
+				sd.DestIPv6Host = new(int64(dipIntHost))       // #nosec G115 -- Used in parquet struct with convertedType=UINT_64
 			}
 		}
 	case 0:
@@ -270,8 +253,7 @@ func (edm *DnstapMinimiser) newSession(dt *dnstap.Dnstap, msg *dns.Msg, isQuery 
 	}
 
 	if dt.Message.SocketProtocol != nil {
-		dnsProtocol := int32(dt.Message.GetSocketProtocol())
-		sd.DNSProtocol = &dnsProtocol
+		sd.DNSProtocol = new(int32(dt.Message.GetSocketProtocol()))
 	}
 
 	return sd

--- a/pkg/runner/session_test.go
+++ b/pkg/runner/session_test.go
@@ -127,10 +127,6 @@ func TestEDMIP6BytesToInt(t *testing.T) {
 	}
 }
 
-func ptr[T any](v T) *T {
-	return &v
-}
-
 func BenchmarkSessionWriter(b *testing.B) {
 	b.ReportAllocs()
 
@@ -153,24 +149,24 @@ func BenchmarkSessionWriter(b *testing.B) {
 
 	sd := sessionData{
 		dnsLabels: dnsLabels{
-			Label0: ptr("com"),
-			Label1: ptr("example"),
-			Label2: ptr("www"),
+			Label0: new("com"),
+			Label1: new("example"),
+			Label2: new("www"),
 		},
-		ServerID:          ptr("serverID"),
-		QueryTime:         ptr(int64(10)),
-		ResponseTime:      ptr(int64(10)),
+		ServerID:          new("serverID"),
+		QueryTime:         new(int64(10)),
+		ResponseTime:      new(int64(10)),
 		SourceIPv4:        &i32IPInt,
 		DestIPv4:          &i32IPInt,
 		SourceIPv6Network: &ip6NetworkInt,
 		SourceIPv6Host:    &ip6HostInt,
 		DestIPv6Network:   &ip6NetworkInt,
 		DestIPv6Host:      &ip6HostInt,
-		SourcePort:        ptr(int32(1337)),
-		DestPort:          ptr(int32(1337)),
-		DNSProtocol:       ptr(int32(1)),
-		QueryMessage:      ptr("query message"),
-		ResponseMessage:   ptr("response message"),
+		SourcePort:        new(int32(1337)),
+		DestPort:          new(int32(1337)),
+		DNSProtocol:       new(int32(1)),
+		QueryMessage:      new("query message"),
+		ResponseMessage:   new("response message"),
 	}
 
 	for b.Loop() {
@@ -207,24 +203,24 @@ func TestSessionWriter(t *testing.T) {
 
 	sd := sessionData{
 		dnsLabels: dnsLabels{
-			Label0: ptr("com"),
-			Label1: ptr("example"),
-			Label2: ptr("www"),
+			Label0: new("com"),
+			Label1: new("example"),
+			Label2: new("www"),
 		},
-		ServerID:          ptr("serverID"),
-		QueryTime:         ptr(int64(10)),
-		ResponseTime:      ptr(int64(10)),
+		ServerID:          new("serverID"),
+		QueryTime:         new(int64(10)),
+		ResponseTime:      new(int64(10)),
 		SourceIPv4:        &i32IPInt,
 		SourceIPv6Network: &ip6NetworkInt,
 		SourceIPv6Host:    &ip6HostInt,
 		DestIPv6Network:   &ip6NetworkInt,
 		DestIPv6Host:      &ip6HostInt,
 		DestIPv4:          &i32IPInt,
-		SourcePort:        ptr(int32(1337)),
-		DestPort:          ptr(int32(1337)),
-		DNSProtocol:       ptr(int32(1)),
-		QueryMessage:      ptr("query message"),
-		ResponseMessage:   ptr("response message"),
+		SourcePort:        new(int32(1337)),
+		DestPort:          new(int32(1337)),
+		DNSProtocol:       new(int32(1)),
+		QueryMessage:      new("query message"),
+		ResponseMessage:   new("response message"),
 	}
 
 	_, err = parquetWriter.Write([]sessionData{sd})
@@ -327,7 +323,7 @@ func TestSessionParquetAndSessionConstruction(t *testing.T) {
 		t.Fatalf("overflow response timestamp = %v, want Unix zero", zeroTS)
 	}
 
-	badMsg, _ := edm.parsePacket(&dnstap.Dnstap{Message: &dnstap.Message{QueryMessage: []byte{1}, QueryTimeSec: ptr(uint64(0)), QueryTimeNsec: ptr(uint32(0))}}, true)
+	badMsg, _ := edm.parsePacket(&dnstap.Dnstap{Message: &dnstap.Message{QueryMessage: []byte{1}, QueryTimeSec: new(uint64(0)), QueryTimeNsec: new(uint32(0))}}, true)
 	if badMsg != nil {
 		t.Fatal("bad query packet returned non-nil message")
 	}


### PR DESCRIPTION
Since [Go 1.26](https://go.dev/doc/go1.26#language) the `new(...)` builtin accepts expressions, make use of this to simplify the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the application build environment to Go 1.26.
  * Improved internal handling of session and event data while preserving existing behavior.
* **Testing**
  * Updated automated tests and benchmarks to align with the latest implementation patterns.
  * Preserved existing validation for DNS packet parsing, session processing, histogram generation, and file creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->