### PR TITLE
Help dns.NextLabel by skipping ahead one label at a time

### DIFF
--- a/pkg/runner/wkd.go
+++ b/pkg/runner/wkd.go
@@ -77,11 +77,13 @@ func getDawgIndex(dawgFinder dawg.Finder, name string) (int, bool) {
 		// Next try to look up suffix matches, so for the name
 		// "www.example.com." we will check for the strings
 		// ".example.com." and ".com.".
-		for index, end := dns.NextLabel(name, 0); !end; index, end = dns.NextLabel(name, index) {
+		for index, end := dns.NextLabel(name, 0); !end; index, end = dns.NextLabel(name, 0) {
 			dawgIndex = dawgFinder.IndexOf(name[index-1:])
 			if dawgIndex != dawgNotFound {
 				return dawgIndex, true
 			}
+			// skip ahead last label
+			name = name[index:]
 		}
 	}
 


### PR DESCRIPTION
Should be no functional difference, but a bit quicker.

Documentation: [`dns.NextLabel`](https://pkg.go.dev/github.com/miekg/dns#NextLabel)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS label suffix matching to ensure the correct index is used when checking domain names.
  * No changes to public APIs or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->